### PR TITLE
Various style improvements of monitor and spring input

### DIFF
--- a/packages/plugin-spring/src/SpringCanvas.tsx
+++ b/packages/plugin-spring/src/SpringCanvas.tsx
@@ -18,6 +18,7 @@ export function SpringCanvas() {
 
   const springRef = useRef(displayValue)
   const accentColor = useTh('colors', 'highlight3')
+  const backgroundColor = useTh('colors', 'elevation2')
   const fillColor = useTh('colors', 'highlight1')
 
   const [gradientTop, gradientBottom] = useMemo(() => {
@@ -60,28 +61,41 @@ export function SpringCanvas() {
       const { tension, friction, mass } = springRef.current
       const { width, height } = _canvas
       const t = springFn(tension, friction, mass)
-      _ctx.clearRect(0, 0, width, height)
-      _ctx.beginPath()
+
+      // compute the path
+      const path = new Path2D()
       let max = 0
       for (let i = 0; i < width; i++) {
         const v = (t(i * 8) * height) / 2
         if (Number.isFinite(v)) max = Math.max(max, v)
-        _ctx.lineTo(i, height - v)
+        path.lineTo(i, height - v)
       }
 
-      const gradient = _ctx.createLinearGradient(0, max, 0, height)
+      // clear
+      _ctx.clearRect(0, 0, width, height)
+
+      // draw gradient
+      const gradientPath = new Path2D(path)
+      gradientPath.lineTo(width - 1, height)
+      gradientPath.lineTo(0, height)
+      const gradient = _ctx.createLinearGradient(0, height / 2, 0, height)
       gradient.addColorStop(0.0, gradientTop)
       gradient.addColorStop(1.0, gradientBottom)
       _ctx.fillStyle = gradient
+      _ctx.fill(gradientPath)
+
+      // draw the dark line
+      _ctx.strokeStyle = backgroundColor
+      _ctx.lineJoin = 'round'
+      _ctx.lineWidth = 14
+      _ctx.stroke(path)
+
+      // draw the white line
       _ctx.strokeStyle = accentColor
       _ctx.lineWidth = 2
-
-      _ctx.stroke()
-      _ctx.lineTo(width - 1, height)
-      _ctx.lineTo(0, height)
-      _ctx.fill()
+      _ctx.stroke(path)
     },
-    [accentColor, gradientTop, gradientBottom]
+    [accentColor, backgroundColor, gradientTop, gradientBottom]
   )
 
   const [canvas, ctx] = useCanvas2d(drawSpring)


### PR DESCRIPTION
Various improvements to the monitor and spring input. 

#### - added the spacing between the curve and the gradient
| Before | After |
|--------|------|
| <img width="287" alt="Screenshot 2021-02-15 at 19 03 52" src="https://user-images.githubusercontent.com/7217420/108082800-be867e80-7072-11eb-8de8-3992d7e15c44.png"> | <img width="288" alt="Screenshot 2021-02-15 at 19 03 15" src="https://user-images.githubusercontent.com/7217420/108082818-c514f600-7072-11eb-94af-875168f49814.png"> |

#### - Spring: fix the gradient banding issue

<img width="342" alt="Screenshot 2021-02-16 at 16 09 08" src="https://user-images.githubusercontent.com/7217420/108083320-38b70300-7073-11eb-93db-a73f7b36ccbb.png">


#### - Monitor: the Y was inverted, now it's correct, add some padding on top and bottom so the line doesn't get cut off

**Before**

 https://user-images.githubusercontent.com/7217420/108081897-c134a400-7071-11eb-90ba-7d00bba888e2.mov 

**After**

https://user-images.githubusercontent.com/7217420/108081910-c42f9480-7071-11eb-886d-18c61a72ac47.mov 


