### PR TITLE
Vector all keys supported

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -30,7 +30,7 @@ function Comp1() {
 
   const t = useControls({
     folder5: folder({
-      boolean2: false,
+      boolean: false,
     }),
     firstsuperlonglabel: { value: 10, step: 0.25 },
     myPlugin: greenOrBlue({ color: 'green', light: true, alpha: 0.5 }),
@@ -40,19 +40,22 @@ function Comp1() {
     interval: { min: -100, max: 100, value: [10, 15] },
     boolean: true,
     refMonitor: monitor(ref, { graph: true, interval: 30 }),
-    // number: { value: 1000, min: 3 },
+    number: { value: 1000, min: 3 },
     folder2: folder(
       {
-        color: { value: '#ff005b', render: (get) => get('boolean') },
-        spring: spring({ tension: 100, mass: 1 }),
+        color2: '#fff',
+        color: {
+          value: '#ff005b',
+          render: (get) => get('boolean'),
+        },
         folder3: folder(
           {
             'Hello Button': button(() => console.log('hello')),
             folder4: folder({
-              string: 'hello',
-              pos2d: { value: { x: 3, y: 4 }, label: 'vector2d' },
-              pos2dArr: [100, 200],
-              pos3d: { value: { x: 0.3, y: 0.1, z: 0.5 }, x: { min: 0 } },
+              spring: spring(),
+              pos2d: { value: { x: 3, y: 4 } },
+              pos2dArr: { value: [100, 200], x: { max: 300 } },
+              pos3d: { value: { x: 0.3, k: 0.1, z: 0.5 }, j: { min: 0 } },
               pos3dArr: [Math.PI / 2, 20, 4],
             }),
           },
@@ -67,6 +70,10 @@ function Comp1() {
 
   // console.log(t.colorObj)
   // console.log(t.pos2d)
+  // console.log(t.pos2dArr)
+  // console.log(t.pos3d)
+  // console.log(t.pos3dArr)
+  // console.log(t.spring)
   // console.log(t.spring)
   // console.log(t.myPlugin)
 
@@ -122,7 +129,7 @@ export function App1() {
         <div>
           {c1 && <Comp1 />}
           {c2 && <Comp1 />}
-          <Comp2 />
+          {/* <Comp2 /> */}
           <button onClick={() => setC1((t) => !t)}>{c1 ? 'Hide' : 'Show'} Json</button>
           <button onClick={() => setC2((t) => !t)}>{c2 ? 'Hide' : 'Show'} Scene</button>
         </div>

--- a/example/src/MultipleStores.tsx
+++ b/example/src/MultipleStores.tsx
@@ -5,30 +5,32 @@ import { useDrag, addV } from 'react-use-gesture'
 function Box({ index, selected, setSelect }) {
   const [{ position, size, fill, color, width }, store, set] = usePanel({
     position: { value: [window.innerWidth / 2 - 150, window.innerHeight / 2], step: 1 },
-    size: { value: [100, 100], min: 10 },
+    size: { value: { width: 100, height: 100 }, min: 10 },
     fill: '#cfcfcf',
     stroke: folder({ color: '#555555', width: { value: 1, min: 0, max: 10 } }),
   })
 
-  const bind = useDrag(({ first, movement: [x, y], args: [control, mod], memo = { p: position, s: size } }) => {
-    if (first) setSelect([index, store])
-    let v
-    switch (control) {
-      case 'position':
-        v = { position: addV(memo.p, [x, y]) }
-        break
-      case 'width':
-        v = { size: [memo.s[0] + x * mod, memo.s[1]] }
-        if (mod === -1) v.position = [memo.p[0] + x, memo.p[1]]
-        break
-      case 'height':
-        v = { size: [memo.s[0], memo.s[1] + y * mod] }
-        if (mod === -1) v.position = [memo.p[0], memo.p[1] + y]
-        break
+  const bind = useDrag(
+    ({ first, movement: [x, y], args: [control, mod], memo = { p: position, s: Object.values(size) } }) => {
+      if (first) setSelect([index, store])
+      let v
+      switch (control) {
+        case 'position':
+          v = { position: addV(memo.p, [x, y]) }
+          break
+        case 'width':
+          v = { size: [memo.s[0] + x * mod, memo.s[1]] }
+          if (mod === -1) v.position = [memo.p[0] + x, memo.p[1]]
+          break
+        case 'height':
+          v = { size: [memo.s[0], memo.s[1] + y * mod] }
+          if (mod === -1) v.position = [memo.p[0], memo.p[1] + y]
+          break
+      }
+      set(v)
+      return memo
     }
-    set(v)
-    return memo
-  })
+  )
 
   useEffect(() => {
     setSelect([index, store])
@@ -40,8 +42,8 @@ function Box({ index, selected, setSelect }) {
       className={`box ${selected ? 'selected' : ''}`}
       style={{
         background: fill,
-        width: size[0],
-        height: size[1],
+        width: size.width,
+        height: size.height,
         border: `${width}px solid ${color}`,
         transform: `translate(${position[0]}px, ${position[1]}px)`,
       }}>

--- a/packages/leva/package.json
+++ b/packages/leva/package.json
@@ -18,7 +18,7 @@
     ]
   },
   "dependencies": {
-    "@stitches/react": "^0.1.0-canary.3",
+    "@stitches/react": "^0.1.0-canary.5",
     "@welldone-software/why-did-you-render": "^6.0.5",
     "clipboard-polyfill": "^3.0.2",
     "dequal": "^2.0.2",

--- a/packages/leva/src/components/Interval/interval-plugin.ts
+++ b/packages/leva/src/components/Interval/interval-plugin.ts
@@ -2,7 +2,7 @@ import v8n from 'v8n'
 import { IntervalInput } from '../../types'
 import { clamp } from '../../utils'
 import { InternalNumberSettings } from '../Number/number-plugin'
-import { normalizeKeyedNumberInput } from '../Vector/vector-utils'
+import { normalizeKeyedNumberSettings } from '../Vector/vector-utils'
 
 export type Interval = IntervalInput['value']
 export type InternalInterval = { min: number; max: number }
@@ -27,7 +27,7 @@ export const sanitize = (
 
 export const normalize = ({ value, min, max }: IntervalInput) => {
   const boundsSettings = { min, max }
-  const { settings } = normalizeKeyedNumberInput(format(value), { min: boundsSettings, max: boundsSettings })
+  const settings = normalizeKeyedNumberSettings(format(value), { min: boundsSettings, max: boundsSettings })
   const bounds: [number, number] = [min, max]
   return { value, settings: { ...settings, bounds } }
 }

--- a/packages/leva/src/components/ValueInput/StyledInput.ts
+++ b/packages/leva/src/components/ValueInput/StyledInput.ts
@@ -9,7 +9,7 @@ export const StyledInput = styled('input', {
   height: '$rowHeight',
   flex: 1,
 
-  variants: { levaType: { number: { textAlign: 'right' } } },
+  variants: { levaType: { number: { textAlign: 'right' }, undefined: {} } },
 })
 
 export const InnerLabel = styled('div', {

--- a/packages/leva/src/components/ValueInput/ValueInput.tsx
+++ b/packages/leva/src/components/ValueInput/ValueInput.tsx
@@ -31,7 +31,6 @@ export function ValueInput({ children, value, onUpdate, onChange, onKeyDown, typ
     [update, onUpdate]
   )
 
-  // TODO fix TS
   return (
     <InputContainer>
       {children && <InnerLabel>{children}</InnerLabel>}

--- a/packages/leva/src/components/Vector/vector-utils.ts
+++ b/packages/leva/src/components/Vector/vector-utils.ts
@@ -1,7 +1,7 @@
 import { NumberSettings } from '../../types'
 import { InternalNumberSettings, normalize } from '../Number/number-plugin'
 
-export const normalizeKeyedNumberInput = <V extends Record<string, number>>(
+export const normalizeKeyedNumberSettings = <V extends Record<string, number>>(
   value: V,
   settings: { [key in keyof V]?: NumberSettings }
 ) => {
@@ -25,5 +25,5 @@ export const normalizeKeyedNumberInput = <V extends Record<string, number>>(
     }
   }
 
-  return { value, settings: _settings }
+  return _settings
 }

--- a/packages/leva/src/components/Vector2d/Vector2d.tsx
+++ b/packages/leva/src/components/Vector2d/Vector2d.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { styled } from '../../styles'
-import { Vector } from '../Vector'
-import { InternalVector2dSettings } from './vector2d-plugin'
-import { LevaInputProps, Vector2d, Vector2dObject } from '../../types'
+import { InternalVectorSettings, Vector } from '../Vector'
+import { LevaInputProps, Vector2d, Vector as VectorType } from '../../types'
 import { Label, Row } from '../UI'
 import { Joystick } from './Joystick'
 import { useInputContext } from '../../context'
 
-export type Vector2dProps = LevaInputProps<Vector2d, InternalVector2dSettings, Vector2dObject>
+export type InternalVector2dSettings = InternalVectorSettings<string, [string, string]>
+export type Vector2dProps = LevaInputProps<Vector2d, InternalVector2dSettings, VectorType>
 
 export const Container = styled('div', {
   display: 'grid',

--- a/packages/leva/src/components/Vector2d/index.ts
+++ b/packages/leva/src/components/Vector2d/index.ts
@@ -1,8 +1,7 @@
 import { Vector2dComponent } from './Vector2d'
-import { KEYS } from '../Vector2d/vector2d-plugin'
 import { getVectorPlugin } from '../Vector'
 
-const plugin = { ...getVectorPlugin(KEYS), component: Vector2dComponent }
+const plugin = { ...getVectorPlugin(['x', 'y']), component: Vector2dComponent }
 
 export * from './Vector2d'
 export default plugin

--- a/packages/leva/src/components/Vector2d/vector2d-plugin.ts
+++ b/packages/leva/src/components/Vector2d/vector2d-plugin.ts
@@ -1,7 +1,0 @@
-import { Format } from '../Vector'
-import { InternalNumberSettings } from '../Number/number-plugin'
-import { Vector2dObject } from '../../types'
-
-export type InternalVector2dSettings = { [key in keyof Vector2dObject]: InternalNumberSettings } & { format: Format }
-
-export const KEYS: (keyof Vector2dObject)[] = ['x', 'y']

--- a/packages/leva/src/components/Vector3d/Vector3d.tsx
+++ b/packages/leva/src/components/Vector3d/Vector3d.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { styled } from '../../styles'
-import { LevaInputProps, Vector3d, Vector3dObject } from '../../types'
-import { Vector } from '../Vector'
+import { Vector, InternalVectorSettings } from '../Vector'
+import { LevaInputProps, Vector3d, Vector as VectorType } from '../../types'
 import { Label, Row } from '../UI'
-import { InternalVector3dSettings } from './vector3d-plugin'
 import { useInputContext } from '../../context'
 
-type Vector3dProps = LevaInputProps<Vector3d, InternalVector3dSettings, Vector3dObject>
+export type InternalVector3dSettings = InternalVectorSettings<string, [string, string, string]>
+export type Vector3dProps = LevaInputProps<Vector3d, InternalVector3dSettings, VectorType>
 
 export const Container = styled('div', {
   display: 'grid',

--- a/packages/leva/src/components/Vector3d/index.ts
+++ b/packages/leva/src/components/Vector3d/index.ts
@@ -1,8 +1,7 @@
 import { Vector3dComponent } from './Vector3d'
-import { KEYS } from '../Vector3d/vector3d-plugin'
 import { getVectorPlugin } from '../Vector'
 
-const plugin = { ...getVectorPlugin(KEYS), component: Vector3dComponent }
+const plugin = { ...getVectorPlugin(['x', 'y', 'z']), component: Vector3dComponent }
 
 export * from './Vector3d'
 export default plugin

--- a/packages/leva/src/components/Vector3d/vector3d-plugin.ts
+++ b/packages/leva/src/components/Vector3d/vector3d-plugin.ts
@@ -1,7 +1,0 @@
-import { Format } from '../Vector'
-import { InternalNumberSettings } from '../Number/number-plugin'
-import { Vector3dObject } from '../../types'
-
-export type InternalVector3dSettings = { [key in keyof Vector3dObject]: InternalNumberSettings } & { format: Format }
-
-export const KEYS: (keyof Vector3dObject)[] = ['x', 'y', 'z']

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -34,7 +34,7 @@ export type Plugin<Input, Value = Input, Settings = {}, InternalSettings = {}> =
   component: React.ComponentType
   schema?: (value: any, settings?: Settings) => boolean
   format?: (value: any, settings: InternalSettings) => any
+  normalize?: (input: Input) => { value: Value; settings?: InternalSettings }
   validate?: (value: any, settings: InternalSettings) => boolean
   sanitize?: (value: any, settings: InternalSettings) => Value
-  normalize?: (input: Input) => { value: Value; settings?: InternalSettings }
 }

--- a/packages/leva/src/utilities.ts
+++ b/packages/leva/src/utilities.ts
@@ -3,5 +3,5 @@ import tinycolor2 from 'tinycolor2'
 
 export { debounce, clamp, pad, orderKeys } from './utils'
 export * from './components/Vector/vector-plugin'
-export { normalizeKeyedNumberInput } from './components/Vector/vector-utils'
+export { normalizeKeyedNumberSettings } from './components/Vector/vector-utils'
 export { tinycolor2 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1560,17 +1560,17 @@
     webpack "^4.44.1"
     webpack-bundle-analyzer "^4.4.0"
 
-"@stitches/core@^0.1.0-canary.3":
-  version "0.1.0-canary.3"
-  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-0.1.0-canary.3.tgz#6431bebfe3c00772fabc6286b3de0f6f37245084"
-  integrity sha512-axvTk7nwIvv9bZvsJ8j/DoUz2pUV/idE7FlERHWApr1llAP6NgRXH45Ez02CKCfL8eNyQQKBortmESufq7sUKA==
+"@stitches/core@^0.1.0-canary.5":
+  version "0.1.0-canary.5"
+  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-0.1.0-canary.5.tgz#a0c32e33676606097c4841b3175cd1de7028e60f"
+  integrity sha512-WfAVbKUcqAfg3tzLyZ5JnU1pHCOgHFKbJMhKcvSc/sdQPrQTk6nFs/X3V/FipUNTHXN0Ycw4+zP/VUFGaIPpzg==
 
-"@stitches/react@^0.1.0-canary.3":
-  version "0.1.0-canary.3"
-  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-0.1.0-canary.3.tgz#1172606bc5a7c72b238253651633f484dd96f9aa"
-  integrity sha512-uIhBPR3tgttNXBjhN45Ybcfr3Rd9P/tshXfGe7AW0xMySvdYMrNYLIMQDAWvSG2z7cS0UlLF0ekPzVZonTQMHA==
+"@stitches/react@^0.1.0-canary.5":
+  version "0.1.0-canary.5"
+  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-0.1.0-canary.5.tgz#acc3fd2866c23a44d1cac03278ae64b2194ea0e3"
+  integrity sha512-t7JbvFVwIdgcJZWf+v+39U1JZ3me+mMC8MIJ9SiBP7Fbh6M6o2DpclnBeTsdAnSklIs9LRI938JUPa4fQ4ILiA==
   dependencies:
-    "@stitches/core" "^0.1.0-canary.3"
+    "@stitches/core" "^0.1.0-canary.5"
 
 "@storybook/addon-actions@6.1.17", "@storybook/addon-actions@^6.1.17":
   version "6.1.17"
@@ -9703,9 +9703,9 @@ react-textarea-autosize@^8.1.1:
     use-latest "^1.0.0"
 
 react-use-gesture@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-9.0.2.tgz#e6871938bffb5275a7d374e5daa27cf9602adaf3"
-  integrity sha512-9UxZsnExGH7RHQAbNj08Qnlo4OKYQrXJ203EBOfNLw1dAusTH+PZNlLqmK21hY00O9Kf1q2n85U2JWczobuzcw==
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-9.0.4.tgz#7e0428007df31b6d8daae37c2fb01e9f40283623"
+  integrity sha512-G0sbQY+HSm2gSVIlD+LE1unpVpG7YZRTr8TI72vo0Nu1lecJtvjbcY3ZLonEZLTtODJgLL6nBllMRXyy0bRSQA==
 
 react@^17.0.1:
   version "17.0.1"


### PR DESCRIPTION
This PR allows the following:

```js
const { size: { width, height }} = useControls({ size: { width: 100, height: 100 } })
```

So that the labels are nicely rendered with the initial of keys 👨‍🍳 

<img width="240" alt="image" src="https://user-images.githubusercontent.com/5003380/108092247-cc410180-707c-11eb-8bf1-693b3b546dc4.png">