### PR TITLE
Feat: no joystick on vector2d

### DIFF
--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -37,6 +37,7 @@ function Controls() {
     folder: folder({
       boolean: false,
       spring: { tension: 100, friction: 30 },
+      noJoy: { value: [1, 2], joystick: false },
     }),
   })
   return <pre>{JSON.stringify(data, null, '  ')}</pre>

--- a/packages/leva/src/components/UI/StyledUI.ts
+++ b/packages/leva/src/components/UI/StyledUI.ts
@@ -48,6 +48,7 @@ export const StyledLabel = styled('label', {
   fontWeight: '$label',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
   variants: {
     align: {
       top: {

--- a/packages/leva/src/components/Vector/vector-plugin.ts
+++ b/packages/leva/src/components/Vector/vector-plugin.ts
@@ -1,5 +1,5 @@
 import v8n from 'v8n'
-import { NumberSettings } from '../../types'
+import { InputWithSettings, NumberSettings } from '../../types'
 import { mapArrayToKeys } from '../../utils'
 import { InternalNumberSettings, sanitize, validate } from '../Number/number-plugin'
 import { normalizeKeyedNumberSettings } from './vector-utils'
@@ -96,7 +96,8 @@ export function normalizeVector<Value extends VectorType, K extends string>(
 export function getVectorPlugin<K extends string>(defaultKeys: K[]) {
   return {
     schema: getVectorSchema(defaultKeys.length),
-    normalize: ({ value, ...settings }: any) => normalizeVector(value, settings, defaultKeys),
+    normalize: <Value extends VectorType>({ value, ...settings }: InputWithSettings<Value, VectorSettings<Value, K>>) =>
+      normalizeVector(value, settings, defaultKeys),
     validate: validateVector,
     format: (value: any, settings: InternalVectorSettings) => formatVector(value, settings),
     sanitize: (value: any, settings: InternalVectorSettings) => sanitizeVector(value, settings),

--- a/packages/leva/src/components/Vector2d/Joystick.tsx
+++ b/packages/leva/src/components/Vector2d/Joystick.tsx
@@ -8,7 +8,7 @@ import { Portal } from '../UI'
 import { multiplyStep, useTransform } from '../../hooks'
 import { Vector2d } from '../../types'
 
-type JoystickProps = { value: Vector2d } & Pick<Vector2dProps, 'settings' | 'onUpdate'>
+type JoystickProps = { value: Vector2d } & Pick<Vector2dProps, 'onUpdate' | 'settings'>
 
 export function Joystick({ value, settings, onUpdate }: JoystickProps) {
   const timeout = useRef<number | undefined>()

--- a/packages/leva/src/components/Vector2d/Vector2d.tsx
+++ b/packages/leva/src/components/Vector2d/Vector2d.tsx
@@ -6,13 +6,18 @@ import { Label, Row } from '../UI'
 import { Joystick } from './Joystick'
 import { useInputContext } from '../../context'
 
-export type InternalVector2dSettings = InternalVectorSettings<string, [string, string]>
+export type InternalVector2dSettings = InternalVectorSettings<string, [string, string]> & { joystick: boolean }
 export type Vector2dProps = LevaInputProps<Vector2d, InternalVector2dSettings, VectorType>
 
 export const Container = styled('div', {
   display: 'grid',
-  gridTemplateColumns: '$sizes$rowHeight repeat(2, 1fr)',
   columnGap: '$colGap',
+  variants: {
+    withJoystick: {
+      true: { gridTemplateColumns: '$sizes$rowHeight repeat(2, 1fr)' },
+      false: { gridTemplateColumns: 'repeat(2, 1fr)' },
+    },
+  },
 })
 
 export function Vector2dComponent() {
@@ -20,8 +25,8 @@ export function Vector2dComponent() {
   return (
     <Row input>
       <Label>{label}</Label>
-      <Container>
-        <Joystick value={displayValue} settings={settings} onUpdate={onUpdate} />
+      <Container withJoystick={settings.joystick}>
+        {settings.joystick && <Joystick value={displayValue} settings={settings} onUpdate={onUpdate} />}
         <Vector value={displayValue} settings={settings} onUpdate={onUpdate} />
       </Container>
     </Row>

--- a/packages/leva/src/components/Vector2d/index.ts
+++ b/packages/leva/src/components/Vector2d/index.ts
@@ -1,10 +1,17 @@
-import { Vector2dComponent } from './Vector2d'
+import { InternalVector2dSettings, Vector2dComponent } from './Vector2d'
 import { getVectorPlugin } from '../Vector'
 import { createInternalPlugin } from '../../plugin'
 
 export * from './Vector2d'
 
+const plugin = getVectorPlugin(['x', 'y'])
+const normalize = ({ joystick = true, ...input }: any) => {
+  const { value, settings } = plugin.normalize(input)
+  return { value, settings: { ...settings, joystick } as InternalVector2dSettings }
+}
+
 export default createInternalPlugin({
   component: Vector2dComponent,
-  ...getVectorPlugin(['x', 'y']),
+  ...plugin,
+  normalize,
 })

--- a/packages/leva/src/types/public-types.ts
+++ b/packages/leva/src/types/public-types.ts
@@ -46,7 +46,7 @@ type NumberInput = MergedInputWithSettings<number, NumberSettings>
 export type Vector = Record<string, number>
 export type Vector2dArray = [number, number]
 export type Vector2d = Vector2dArray | Vector
-export type Vector2dSettings = VectorSettings<Vector2d, 'x' | 'y'>
+export type Vector2dSettings = VectorSettings<Vector2d, 'x' | 'y'> & { joystick?: boolean }
 export type Vector2dInput = MergedInputWithSettings<Vector2d, Vector2dSettings>
 
 export type Vector3dArray = [number, number, number]


### PR DESCRIPTION
Allows this:

```js
useControls({ noJoystickVector: { value: [1, 2], joystick: false } })
```

<img width="269" alt="image" src="https://user-images.githubusercontent.com/5003380/109390210-8acc1400-7910-11eb-9a2d-95ebd66a0a4b.png">
