### PR TITLE
Feat: road to vector lock

### DIFF
--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -27,6 +27,7 @@ const ExtraControls = () => {
 function Controls() {
   const data = useControls({
     range: { value: 0, min: -10, max: 10 },
+    dimension: '4px',
     image: { image: undefined },
     select: { options: ['x', 'y', ['x', 'y']] },
     interval: { min: -100, max: 100, value: [-10, 10] },

--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -15,7 +15,7 @@ const ExtraControls = () => {
   const data = useControls('folder.subfolder', {
     'Hello Button': button(() => console.log('hello')),
     'deep nested': folder({
-      pos2d: { x: 3, y: 4 },
+      pos2d: { value: { x: 3, y: 4 }, lock: true },
       pos2dArr: [100, 200],
       pos3d: { x: 0.3, y: 0.1, z: 0.5 },
       pos3dArr: [Math.PI / 2, 20, 4],

--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -47,9 +47,11 @@ export default function App() {
   const [count, setCount] = React.useState(0)
   const [show, setShow] = React.useState(true)
 
+  const { hideTitleBar, oneLineLabels } = useControls({ hideTitleBar: false, oneLineLabels: false })
+
   return (
     <>
-      <Leva />
+      <Leva hideTitleBar={hideTitleBar} oneLineLabels={oneLineLabels} />
       <div className={styles.buttons}>
         Reference count: {count}
         <button onClick={() => setCount((c) => Math.max(0, c - 1))}>-</button>

--- a/packages/leva/src/components/Control/Control.tsx
+++ b/packages/leva/src/components/Control/Control.tsx
@@ -15,7 +15,7 @@ const specialComponents = {
 }
 
 export const Control = React.memo(({ path }: ControlProps) => {
-  const [input, set] = useInput(path)
+  const [input, set, setSettings] = useInput(path)
 
   const { type, label, key, ...inputProps } = input
 
@@ -30,6 +30,16 @@ export const Control = React.memo(({ path }: ControlProps) => {
     return null
   }
 
-  // @ts-expect-error
-  return <ControlInput type={type} label={label} path={path} valueKey={key} {...inputProps} setValue={set} />
+  return (
+    // @ts-expect-error
+    <ControlInput
+      type={type}
+      label={label}
+      path={path}
+      valueKey={key}
+      setValue={set}
+      setSettings={setSettings}
+      {...inputProps}
+    />
+  )
 })

--- a/packages/leva/src/components/Control/ControlInput.tsx
+++ b/packages/leva/src/components/Control/ControlInput.tsx
@@ -11,6 +11,7 @@ type ControlInputProps<V, Settings extends object> = {
   value: V
   settings: Settings
   setValue: (value: any) => void
+  setSettings: (settings: any) => void
 }
 
 export function ControlInput<V, Settings extends object>({
@@ -21,12 +22,25 @@ export function ControlInput<V, Settings extends object>({
   value,
   settings,
   setValue,
+  setSettings,
 }: ControlInputProps<V, Settings>) {
   const { displayValue, onChange, onUpdate } = useValue({ type, value, settings, setValue })
   const Input = Plugins[type].component
 
   return (
-    <InputContext.Provider value={{ key: valueKey, path, label, displayValue, value, onChange, onUpdate, settings }}>
+    <InputContext.Provider
+      value={{
+        key: valueKey,
+        path,
+        label,
+        displayValue,
+        value,
+        onChange,
+        onUpdate,
+        settings,
+        setValue,
+        setSettings,
+      }}>
       <Input />
     </InputContext.Provider>
   )

--- a/packages/leva/src/components/Interval/Interval.tsx
+++ b/packages/leva/src/components/Interval/Interval.tsx
@@ -18,7 +18,6 @@ type IntervalSliderProps = {
 
 const Container = styled('div', {
   display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
   columnGap: '$colGap',
   gridColumnStart: 2,
 })

--- a/packages/leva/src/components/Interval/Interval.tsx
+++ b/packages/leva/src/components/Interval/Interval.tsx
@@ -13,7 +13,7 @@ type IntervalProps = LevaInputProps<IntervalType, InternalIntervalSettings>
 
 type IntervalSliderProps = {
   value: InternalInterval
-  onDrag: (v: InternalInterval) => void
+  onDrag: (v: Partial<InternalInterval>) => void
 } & InternalIntervalSettings
 
 const Container = styled('div', {
@@ -44,7 +44,7 @@ function IntervalSlider({ value, bounds: [min, max], onDrag, ...settings }: Inte
     }
     const newValue = memo.pos + invertedRange(mx / rangeWidth.current, 0, max - min)
 
-    onDrag({ ...value, [memo.key]: sanitizeStep(newValue, settings[memo.key as 'min' | 'max']) })
+    onDrag({ [memo.key]: sanitizeStep(newValue, settings[memo.key as 'min' | 'max']) })
     return memo
   })
 

--- a/packages/leva/src/components/Interval/interval-plugin.ts
+++ b/packages/leva/src/components/Interval/interval-plugin.ts
@@ -21,9 +21,14 @@ export const schema = (o: any, s: any) =>
 export const format = (v: Interval) => ({ min: v[0], max: v[1] })
 
 export const sanitize = (
-  { min, max }: InternalInterval,
-  { bounds: [MIN, MAX] }: InternalIntervalSettings
-): Interval => [clamp(Number(min), MIN, Math.max(MIN, max)), clamp(Number(max), Math.min(MAX, min), MAX)]
+  value: InternalInterval,
+  { bounds: [MIN, MAX] }: InternalIntervalSettings,
+  prevValue: any
+): Interval => {
+  const _newValue = { min: prevValue[0], max: prevValue[1] }
+  const { min, max } = { ..._newValue, ...value }
+  return [clamp(Number(min), MIN, Math.max(MIN, max)), clamp(Number(max), Math.min(MAX, min), MAX)]
+}
 
 export const normalize = ({ value, min, max }: IntervalInput) => {
   const boundsSettings = { min, max }

--- a/packages/leva/src/components/Number/number-plugin.ts
+++ b/packages/leva/src/components/Number/number-plugin.ts
@@ -13,7 +13,7 @@ type NumberInput = InputWithSettings<number | string, NumberSettings>
 
 export const schema = (o: any) => typeof o === 'number' || (typeof o === 'string' && !isNaN(parseNumber(o)))
 
-export const validate = (v: string | number) => v !== '' && !isNaN(Number(v))
+export const validate = (v: string | number) => v !== '' && !isNaN(parseNumber(v))
 
 export const format = (v: any, { pad = 0, suffix }: InternalNumberSettings) => {
   const f = parseNumber(v).toFixed(pad)
@@ -21,14 +21,14 @@ export const format = (v: any, { pad = 0, suffix }: InternalNumberSettings) => {
 }
 
 export const sanitize = (v: string | number, { min = -Infinity, max = Infinity, suffix }: InternalNumberSettings) => {
-  const f = clamp(parseNumber(v as string), min, max)
+  const f = clamp(parseNumber(v), min, max)
   return suffix ? f + suffix : f
 }
 
 export const normalize = ({ value, ...settings }: NumberInput) => {
   const { min, max } = settings
 
-  const _value = parseNumber(value as any)
+  const _value = parseNumber(value)
   let suffix
   if (!Number.isFinite(value)) {
     const match = String(value).match(/[A-Z]+/i)

--- a/packages/leva/src/components/Vector/Vector.tsx
+++ b/packages/leva/src/components/Vector/Vector.tsx
@@ -12,13 +12,12 @@ type CoordinateProps<T extends CoordinateValue> = {
   value: T
   settings: InternalNumberSettings
   valueKey: keyof T
-  onUpdate: (value: T) => void
+  onUpdate: (value: any) => void
 }
 
 function Coordinate<T extends CoordinateValue>({ value, id, valueKey, settings, onUpdate }: CoordinateProps<T>) {
   const args = { type: 'NUMBER', value: value[valueKey], settings }
-
-  const setValue = (newValue: any) => onUpdate({ ...value, [valueKey]: sanitizeValue(args, newValue) })
+  const setValue = (newValue: any) => onUpdate({ [valueKey]: sanitizeValue(args, newValue) })
 
   const number = useValue({ ...args, setValue })
 

--- a/packages/leva/src/components/Vector/Vector.tsx
+++ b/packages/leva/src/components/Vector/Vector.tsx
@@ -39,7 +39,7 @@ type VectorSettings<T extends CoordinateValue> = { [key in keyof T]: InternalNum
 
 type VectorProps<T extends CoordinateValue> = {
   value: T
-  settings: VectorSettings<T> & { lock?: boolean }
+  settings: VectorSettings<T> & { lock?: boolean; locked?: boolean }
   onUpdate: (value: T) => void
 }
 
@@ -87,11 +87,11 @@ export function Vector<T extends CoordinateValue>({ value, onUpdate, settings }:
 
   // TODO atm if lock is explicitly set in settings we show the lock
   // this can probably be improved with better logic.
-  const withLock = settings.lock !== undefined
+  const { lock, locked } = settings
 
   return (
-    <Container withLock={withLock}>
-      {withLock && <Lock locked={settings.lock!} onClick={() => setSettings({ lock: !settings.lock })} />}
+    <Container withLock={lock}>
+      {lock && <Lock locked={locked!} onClick={() => setSettings({ locked: !locked })} />}
       {Object.keys(value).map((key, i) => (
         <Coordinate
           id={i === 0 ? path : `${path}.${key}`}

--- a/packages/leva/src/components/Vector/Vector.tsx
+++ b/packages/leva/src/components/Vector/Vector.tsx
@@ -39,7 +39,7 @@ type VectorSettings<T extends CoordinateValue> = { [key in keyof T]: InternalNum
 
 type VectorProps<T extends CoordinateValue> = {
   value: T
-  settings: VectorSettings<T>
+  settings: VectorSettings<T> & { lock?: boolean }
   onUpdate: (value: T) => void
 }
 
@@ -47,12 +47,51 @@ export const Container = styled('div', {
   display: 'grid',
   columnGap: '$colGap',
   gridAutoFlow: 'column dense',
+  alignItems: 'center',
+  variants: {
+    withLock: {
+      true: {
+        gridTemplateColumns: '10px auto',
+        '> svg': { cursor: 'pointer' },
+      },
+    },
+  },
 })
 
-export function Vector<T extends CoordinateValue>({ value, onUpdate, settings }: VectorProps<T>) {
-  const { path } = useInputContext()
+// TODO increase click area
+
+function Lock({ locked, ...props }: React.HTMLAttributes<SVGElement> & { locked: boolean }) {
   return (
-    <Container>
+    <svg width="10" height="10" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      {locked ? (
+        <path
+          d="M5 4.63601C5 3.76031 5.24219 3.1054 5.64323 2.67357C6.03934 2.24705 6.64582 1.9783 7.5014 1.9783C8.35745 1.9783 8.96306 2.24652 9.35823 2.67208C9.75838 3.10299 10 3.75708 10 4.63325V5.99999H5V4.63601ZM4 5.99999V4.63601C4 3.58148 4.29339 2.65754 4.91049 1.99307C5.53252 1.32329 6.42675 0.978302 7.5014 0.978302C8.57583 0.978302 9.46952 1.32233 10.091 1.99162C10.7076 2.65557 11 3.57896 11 4.63325V5.99999H12C12.5523 5.99999 13 6.44771 13 6.99999V13C13 13.5523 12.5523 14 12 14H3C2.44772 14 2 13.5523 2 13V6.99999C2 6.44771 2.44772 5.99999 3 5.99999H4ZM3 6.99999H12V13H3V6.99999Z"
+          fill="currentColor"
+          fillRule="evenodd"
+          clipRule="evenodd"
+        />
+      ) : (
+        <path
+          d="M9 3.63601C9 2.76044 9.24207 2.11211 9.64154 1.68623C10.0366 1.26502 10.6432 1 11.5014 1C12.4485 1 13.0839 1.30552 13.4722 1.80636C13.8031 2.23312 14 2.84313 14 3.63325H15C15 2.68242 14.7626 1.83856 14.2625 1.19361C13.6389 0.38943 12.6743 0 11.5014 0C10.4294 0 9.53523 0.337871 8.91218 1.0021C8.29351 1.66167 8 2.58135 8 3.63601V6H1C0.447715 6 0 6.44772 0 7V13C0 13.5523 0.447715 14 1 14H10C10.5523 14 11 13.5523 11 13V7C11 6.44772 10.5523 6 10 6H9V3.63601ZM1 7H10V13H1V7Z"
+          fill="currentColor"
+          fillRule="evenodd"
+          clipRule="evenodd"
+        />
+      )}
+    </svg>
+  )
+}
+
+export function Vector<T extends CoordinateValue>({ value, onUpdate, settings }: VectorProps<T>) {
+  const { path, setSettings } = useInputContext()
+
+  // TODO atm if lock is explicitly set in settings we show the lock
+  // this can probably be improved with better logic.
+  const withLock = settings.lock !== undefined
+
+  return (
+    <Container withLock={withLock}>
+      {withLock && <Lock locked={settings.lock!} onClick={() => setSettings({ lock: !settings.lock })} />}
       {Object.keys(value).map((key, i) => (
         <Coordinate
           id={i === 0 ? path : `${path}.${key}`}

--- a/packages/leva/src/components/Vector/Vector.tsx
+++ b/packages/leva/src/components/Vector/Vector.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useInputContext } from '../../context'
+import { styled } from '../../styles'
 import { useValue } from '../../hooks'
 import { sanitizeValue } from '../../utils'
 import { Number } from '../Number'
@@ -42,10 +43,16 @@ type VectorProps<T extends CoordinateValue> = {
   onUpdate: (value: T) => void
 }
 
+export const Container = styled('div', {
+  display: 'grid',
+  columnGap: '$colGap',
+  gridAutoFlow: 'column dense',
+})
+
 export function Vector<T extends CoordinateValue>({ value, onUpdate, settings }: VectorProps<T>) {
   const { path } = useInputContext()
   return (
-    <>
+    <Container>
       {Object.keys(value).map((key, i) => (
         <Coordinate
           id={i === 0 ? path : `${path}.${key}`}
@@ -56,6 +63,6 @@ export function Vector<T extends CoordinateValue>({ value, onUpdate, settings }:
           onUpdate={onUpdate}
         />
       ))}
-    </>
+    </Container>
   )
 }

--- a/packages/leva/src/components/Vector/vector-plugin.ts
+++ b/packages/leva/src/components/Vector/vector-plugin.ts
@@ -53,13 +53,15 @@ function convert<Value extends VectorType, F extends Format, K extends string>(
 export const validateVector = (value: any) => Object.values(value).every((v: any) => validate(v))
 
 export const sanitizeVector = <K extends string, F extends Format>(
-  value: number[] | { [key in K]: number },
-  settings: InternalVectorSettings<K, K[], F>
-): F extends 'array' ? number[] : { [key in K]: number } => {
+  value: VectorType<K>,
+  settings: InternalVectorSettings<K, K[], F>,
+  prevValue: any
+): VectorType<K, F> => {
   const _value = convert(value, 'object', settings.keys) as any
-
-  for (let key in _value) _value[key] = sanitize(_value[key], settings[key as K])
-  return convert(_value, settings.format, settings.keys) as any
+  const _prevValue = convert(prevValue, 'object', settings.keys) as any
+  const _newValue = { ..._prevValue, ..._value }
+  for (let key in _newValue) _newValue[key] = sanitize(_newValue[key], settings[key as K])
+  return convert(_newValue, settings.format, settings.keys) as any
 }
 
 export const formatVector = <K extends string, F extends Format>(
@@ -100,6 +102,7 @@ export function getVectorPlugin<K extends string>(defaultKeys: K[]) {
       normalizeVector(value, settings, defaultKeys),
     validate: validateVector,
     format: (value: any, settings: InternalVectorSettings) => formatVector(value, settings),
-    sanitize: (value: any, settings: InternalVectorSettings) => sanitizeVector(value, settings),
+    sanitize: (value: any, settings: InternalVectorSettings, prevValue: any) =>
+      sanitizeVector(value, settings, prevValue),
   }
 }

--- a/packages/leva/src/components/Vector/vector-plugin.ts
+++ b/packages/leva/src/components/Vector/vector-plugin.ts
@@ -18,11 +18,13 @@ export type VectorObjectSettings<V extends VectorType, K extends string> = GetKe
     : { [key in K]: NumberSettings }
   : { [key in GetKeys<V>]: NumberSettings }
 
-export type VectorSettings<V extends VectorType, K extends string> = NumberSettings | VectorObjectSettings<V, K>
+export type VectorSettings<V extends VectorType, K extends string> = (NumberSettings | VectorObjectSettings<V, K>) & {
+  lock?: boolean
+}
 
 export type InternalVectorSettings<K extends string = string, Keys extends K[] = K[], F extends Format = Format> = {
   [key in K]: InternalNumberSettings
-} & { keys: Keys; format: F }
+} & { keys: Keys; format: F; lock: boolean }
 
 export function getVectorSchema(dimension: number) {
   // prettier-ignore
@@ -73,7 +75,7 @@ const isNumberSettings = (o?: object) => o && ('step' in o || 'min' in o || 'max
 
 export function normalizeVector<Value extends VectorType, K extends string>(
   _value: Value,
-  _settings: VectorSettings<Value, K>,
+  { lock = false, ..._settings }: VectorSettings<Value, K>,
   defaultKeys: K[] = []
 ) {
   const format: Format = Array.isArray(_value) ? 'array' : 'object'
@@ -91,7 +93,7 @@ export function normalizeVector<Value extends VectorType, K extends string>(
   const settings = normalizeKeyedNumberSettings(value, mergedSettings)
   return {
     value: (format === 'array' ? _value : value) as Value,
-    settings: { ...settings, format, keys },
+    settings: { ...settings, format, keys, lock },
   }
 }
 

--- a/packages/leva/src/components/Vector/vector-plugin.ts
+++ b/packages/leva/src/components/Vector/vector-plugin.ts
@@ -24,7 +24,7 @@ export type VectorSettings<V extends VectorType, K extends string> = (NumberSett
 
 export type InternalVectorSettings<K extends string = string, Keys extends K[] = K[], F extends Format = Format> = {
   [key in K]: InternalNumberSettings
-} & { keys: Keys; format: F; lock?: boolean }
+} & { keys: Keys; format: F; lock: boolean; locked: boolean }
 
 export function getVectorSchema(dimension: number) {
   // prettier-ignore
@@ -68,7 +68,7 @@ export const sanitizeVector = <K extends string, F extends Format>(
   else {
     const _prevValue = convert(prevValue, 'object', settings.keys) as any
     // if there's only one key and lock is true we compute the aspect ratio
-    if (_valueKeys.length === 1 && !!settings.lock) {
+    if (_valueKeys.length === 1 && settings.locked) {
       const lockedKey = _valueKeys[0]
       const lockedCoordinate = _value[lockedKey]
       const previousLockedCoordinate = _prevValue[lockedKey]
@@ -117,7 +117,7 @@ export function normalizeVector<Value extends VectorType, K extends string>(
   const settings = normalizeKeyedNumberSettings(value, mergedSettings)
   return {
     value: (format === 'array' ? _value : value) as Value,
-    settings: { ...settings, format, keys, lock },
+    settings: { ...settings, format, keys, lock, locked: false },
   }
 }
 

--- a/packages/leva/src/components/Vector/vector-plugin.ts
+++ b/packages/leva/src/components/Vector/vector-plugin.ts
@@ -60,8 +60,16 @@ export const sanitizeVector = <K extends string, F extends Format>(
   prevValue: any
 ): VectorType<K, F> => {
   const _value = convert(value, 'object', settings.keys) as any
-  const _prevValue = convert(prevValue, 'object', settings.keys) as any
-  const _newValue = { ..._prevValue, ..._value }
+  let _newValue
+
+  // if _value includes all keys of the Vector then _value is the full _newValue
+  if (Object.keys(_value).length === settings.keys.length) _newValue = _value
+  else {
+    // _value is incomplete so we merge the previous value with the new one
+    const _prevValue = convert(prevValue, 'object', settings.keys) as any
+    _newValue = { ..._prevValue, ..._value }
+  }
+
   for (let key in _newValue) _newValue[key] = sanitize(_newValue[key], settings[key as K])
   return convert(_newValue, settings.format, settings.keys) as any
 }

--- a/packages/leva/src/components/Vector2d/Vector2d.tsx
+++ b/packages/leva/src/components/Vector2d/Vector2d.tsx
@@ -14,8 +14,8 @@ export const Container = styled('div', {
   columnGap: '$colGap',
   variants: {
     withJoystick: {
-      true: { gridTemplateColumns: '$sizes$rowHeight repeat(2, 1fr)' },
-      false: { gridTemplateColumns: 'repeat(2, 1fr)' },
+      true: { gridTemplateColumns: '$sizes$rowHeight auto' },
+      false: { gridTemplateColumns: 'auto' },
     },
   },
 })

--- a/packages/leva/src/components/Vector3d/Vector3d.tsx
+++ b/packages/leva/src/components/Vector3d/Vector3d.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { styled } from '../../styles'
 import { Vector, InternalVectorSettings } from '../Vector'
 import { LevaInputProps, Vector3d, Vector as VectorType } from '../../types'
 import { Label, Row } from '../UI'
@@ -8,20 +7,12 @@ import { useInputContext } from '../../context'
 export type InternalVector3dSettings = InternalVectorSettings<string, [string, string, string]>
 export type Vector3dProps = LevaInputProps<Vector3d, InternalVector3dSettings, VectorType>
 
-export const Container = styled('div', {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
-  columnGap: '$colGap',
-})
-
 export function Vector3dComponent() {
   const { label, displayValue, onUpdate, settings } = useInputContext<Vector3dProps>()
   return (
     <Row input>
       <Label>{label}</Label>
-      <Container>
-        <Vector value={displayValue} settings={settings} onUpdate={onUpdate} />
-      </Container>
+      <Vector value={displayValue} settings={settings} onUpdate={onUpdate} />
     </Row>
   )
 }

--- a/packages/leva/src/hooks/useInput.ts
+++ b/packages/leva/src/hooks/useInput.ts
@@ -15,17 +15,18 @@ type Input = Omit<DataItem, 'count'>
  *
  * @param path
  */
-export function useInput(path: string): [Input, (value: any) => void] {
+export function useInput(path: string): [Input, (value: any) => void, (value: any) => void] {
   const store = useStoreContext()
   const [state, setState] = useState<Input>(getInputAtPath(store.getData(), path))
 
   const set = useCallback((value) => store.setValueAtPath(path, value), [path, store])
+  const setSettings = useCallback((settings) => store.setSettingsAtPath(path, settings), [path, store])
 
   useEffect(() => {
     setState(getInputAtPath(store.getData(), path))
     const unsub = store.useStore.subscribe(setState, (s) => getInputAtPath(s.data, path), shallow)
     return () => unsub()
-  }, [store, set, path])
+  }, [store, path])
 
-  return [state, set]
+  return [state, set, setSettings]
 }

--- a/packages/leva/src/plugin.ts
+++ b/packages/leva/src/plugin.ts
@@ -79,9 +79,9 @@ export function normalize<V, Settings extends object = {}>(type: string, input: 
   return input
 }
 
-export function sanitize<Settings extends object>(type: string, value: any, settings?: Settings) {
+export function sanitize<Settings extends object>(type: string, value: any, settings?: Settings, prevValue?: any) {
   const { sanitize } = Plugins[type]
-  if (sanitize) return sanitize(value, settings)
+  if (sanitize) return sanitize(value, settings, prevValue)
   return value
 }
 

--- a/packages/leva/src/store.ts
+++ b/packages/leva/src/store.ts
@@ -17,6 +17,7 @@ export type StoreType = {
   getData: () => Data
   addData: (newData: Data) => void
   setValueAtPath: (path: string, value: any) => void
+  setSettingsAtPath: (path: string, settings: any) => void
   // TODO possibly better type this
   set: (values: Record<string, any>) => void
   get: (path: string) => any
@@ -174,6 +175,15 @@ export const Store = (function (this: StoreType) {
       const data = s.data
       //@ts-expect-error (we always update inputs with a value)
       updateInput(data[path], value)
+      return { data }
+    })
+  }
+
+  this.setSettingsAtPath = (path, settings) => {
+    store.setState((s) => {
+      const data = s.data
+      //@ts-expect-error (we always update inputs with settings)
+      data[path].settings = { ...data[path].settings, ...settings }
       return { data }
     })
   }

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -36,7 +36,7 @@ export type Plugin<Input, Value = Input, InternalSettings = {}> = {
   format?: (value: any, settings: InternalSettings) => any
   normalize?: (input: Input) => { value: Value; settings?: InternalSettings }
   validate?: (value: any, settings: InternalSettings) => boolean
-  sanitize?: (value: any, settings: InternalSettings) => Value
+  sanitize?: (value: any, settings: InternalSettings, prevValue: any) => Value
 }
 
 export type InternalPlugin<Input, Value = Input, Settings = {}, InternalSettings = {}> = Plugin<

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -35,8 +35,8 @@ export type Plugin<Input, Value = Input, InternalSettings = {}> = {
   component: React.ComponentType
   format?: (value: any, settings: InternalSettings) => any
   normalize?: (input: Input) => { value: Value; settings?: InternalSettings }
-  validate?: (value: any, settings: InternalSettings) => boolean
-  sanitize?: (value: any, settings: InternalSettings, prevValue: any) => Value
+  validate?: (value: any, settings: any) => boolean
+  sanitize?: (value: any, settings: any, prevValue: any) => Value
 }
 
 export type InternalPlugin<Input, Value = Input, Settings = {}, InternalSettings = {}> = Plugin<

--- a/packages/leva/src/types/public-types.ts
+++ b/packages/leva/src/types/public-types.ts
@@ -46,12 +46,12 @@ type NumberInput = MergedInputWithSettings<number, NumberSettings>
 export type Vector = Record<string, number>
 export type Vector2dArray = [number, number]
 export type Vector2d = Vector2dArray | Vector
-export type Vector2dSettings = VectorSettings<Vector2d, 'x' | 'y'> & { joystick?: boolean }
+export type Vector2dSettings = VectorSettings<Vector2d, 'x' | 'y'> & { joystick?: boolean; lock?: boolean }
 export type Vector2dInput = MergedInputWithSettings<Vector2d, Vector2dSettings>
 
 export type Vector3dArray = [number, number, number]
 export type Vector3d = Vector3dArray | Vector
-export type Vector3dSettings = VectorSettings<Vector3d, 'x' | 'y' | 'z'>
+export type Vector3dSettings = VectorSettings<Vector3d, 'x' | 'y' | 'z'> & { lock?: boolean }
 export type Vector3dInput = MergedInputWithSettings<Vector3d, Vector3dSettings>
 
 export type IntervalInput = { value: [number, number]; min: number; max: number }

--- a/packages/leva/src/utils/input.ts
+++ b/packages/leva/src/utils/input.ts
@@ -58,7 +58,7 @@ export function sanitizeValue({ type, value, settings }: SanitizeProps, newValue
   if (!validate(type, _newValue, settings)) {
     throw new ValueError(`The value [${newValue}] did not result in a correct value.`, value)
   }
-  const sanitizedNewValue = sanitize(type, _newValue, settings)
+  const sanitizedNewValue = sanitize(type, _newValue, settings, value)
 
   if (dequal(sanitizedNewValue, value)) {
     /**

--- a/packages/leva/src/utils/math.ts
+++ b/packages/leva/src/utils/math.ts
@@ -1,7 +1,13 @@
 export const clamp = (x: number, min: number, max: number) => (x > max ? max : x < min ? min : x)
 export const pad = (x: number, pad: number) => String(x).padStart(pad, '0')
 export const ceil = (v: number) => Math.sign(v) * Math.ceil(Math.abs(v))
-export const parseNumber = (v: number | string) => (typeof v === 'number' ? v : parseFloat(v))
+export const parseNumber = (v: number | string) => {
+  if (typeof v === 'number') return v
+  try {
+    return evaluate(v)
+  } catch {}
+  return parseFloat(v)
+}
 
 const log10 = Math.log(10)
 
@@ -21,3 +27,53 @@ export const invertedRange = (p: number, min: number, max: number) => p * (max -
 
 // from https://gist.github.com/gordonbrander/2230317
 export const uid = () => '_' + Math.random().toString(36).substr(2, 9)
+
+const parens = /\(([0-9+\-*/^ .]+)\)/ // Regex for identifying parenthetical expressions
+const exp = /(\d+(?:\.\d+)?) ?\^ ?(\d+(?:\.\d+)?)/ // Regex for identifying exponentials (x ^ y)
+const mul = /(\d+(?:\.\d+)?) ?\* ?(\d+(?:\.\d+)?)/ // Regex for identifying multiplication (x * y)
+const div = /(\d+(?:\.\d+)?) ?\/ ?(\d+(?:\.\d+)?)/ // Regex for identifying division (x / y)
+const add = /(\d+(?:\.\d+)?) ?\+ ?(\d+(?:\.\d+)?)/ // Regex for identifying addition (x + y)
+const sub = /(\d+(?:\.\d+)?) ?- ?(\d+(?:\.\d+)?)/ // Regex for identifying subtraction (x - y)
+
+/**
+ * Copyright: copied from here: https://stackoverflow.com/a/63105543
+ * by @aanrudolph2 https://github.com/aanrudolph2
+ *
+ * Evaluates a numerical expression as a string and returns a Number
+ * Follows standard PEMDAS operation ordering
+ * @param {String} expr Numerical expression input
+ * @returns {Number} Result of expression
+ */
+function evaluate(expr: string): number {
+  if (isNaN(Number(expr))) {
+    if (parens.test(expr)) {
+      const newExpr = expr.replace(parens, (match, subExpr) => String(evaluate(subExpr)))
+      return evaluate(newExpr)
+    } else if (exp.test(expr)) {
+      const newExpr = expr.replace(exp, (match, base, pow) => String(Math.pow(Number(base), Number(pow))))
+      return evaluate(newExpr)
+    } else if (mul.test(expr)) {
+      const newExpr = expr.replace(mul, (match, a, b) => String(Number(a) * Number(b)))
+      return evaluate(newExpr)
+    } else if (div.test(expr)) {
+      const newExpr = expr.replace(div, (match, a, b) => {
+        // b can equal either 0 or "0" this is on purpose
+        // eslint-disable-next-line eqeqeq
+        if (b != 0) return String(Number(a) / Number(b))
+        else throw new Error('Division by zero')
+      })
+      return evaluate(newExpr)
+    } else if (add.test(expr)) {
+      const newExpr = expr.replace(add, (match, a: string, b: string) => String(Number(a) + Number(b)))
+      return evaluate(newExpr)
+    } else if (sub.test(expr)) {
+      const newExpr = expr.replace(sub, (match, a, b) => String(Number(a) - Number(b)))
+      return evaluate(newExpr)
+    } else {
+      return Number(expr)
+    }
+  }
+  return Number(expr)
+}
+// Example usage
+//console.log(evaluate("2 + 4*(30/5) - 34 + 45/2"));

--- a/packages/leva/stories/inputs/Vector.stories.tsx
+++ b/packages/leva/stories/inputs/Vector.stories.tsx
@@ -1,39 +1,61 @@
-import React from 'react';
-import { Story, Meta } from '@storybook/react';
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
 
 import Reset from '../components/decorator-reset'
 
-import { useControls } from '../../src';
+import { useControls } from '../../src'
 
 export default {
   title: 'Inputs/Vector',
-  decorators: [Reset]
-} as Meta;
+  decorators: [Reset],
+} as Meta
 
 const Template: Story<any> = (args) => {
   const values = useControls({
     foo: args,
   })
-  
-  return <div><pre>{JSON.stringify(values, null, '  ')}</pre></div>;
+
+  return (
+    <div>
+      <pre>{JSON.stringify(values, null, '  ')}</pre>
+    </div>
+  )
 }
 
-export const Vector2 = Template.bind({});
+export const Vector2 = Template.bind({})
 Vector2.args = {
   value: { x: 0, y: 0 },
-};
+}
 
-export const Vector2FromArray = Template.bind({});
+export const Vector2FromArray = Template.bind({})
 Vector2FromArray.args = {
   value: [1, 10],
-};
+}
 
-export const Vector3 = Template.bind({});
+export const Vector2WithLock = Template.bind({})
+Vector2WithLock.args = {
+  value: [1, 10],
+  lock: true,
+}
+
+export const Vector2WithoutJoystick = Template.bind({})
+Vector2WithoutJoystick.args = {
+  value: { x: 0, y: 0 },
+  joystick: false,
+}
+
+export const Vector3 = Template.bind({})
 Vector3.args = {
   value: { x: 0, y: 0, z: 0 },
-};
+}
 
-export const Vector3FromArray = Template.bind({});
+export const Vector3FromArray = Template.bind({})
 Vector3FromArray.args = {
   value: [1, 10, 0],
-};
+}
+
+export const Vector3WithLock = Template.bind({})
+Vector3WithLock.args = {
+  value: [1, 10, 0],
+  lock: true,
+}

--- a/packages/plugin-spring/src/Spring.tsx
+++ b/packages/plugin-spring/src/Spring.tsx
@@ -1,12 +1,6 @@
 import React from 'react'
-import { useInputContext, Vector, Label, Row, styled } from 'leva/plugins'
+import { useInputContext, Vector, Label, Row } from 'leva/plugins'
 import { SpringCanvas, SpringProps } from './SpringCanvas'
-
-const Container = styled('div', {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
-  columnGap: '$colGap',
-})
 
 export function Spring() {
   const { label, displayValue, onUpdate, settings } = useInputContext<SpringProps>()
@@ -18,9 +12,7 @@ export function Spring() {
       </Row>
       <Row input>
         <Label>{label}</Label>
-        <Container>
-          <Vector value={displayValue} settings={settings as any} onUpdate={onUpdate} />
-        </Container>
+        <Vector value={displayValue} settings={settings as any} onUpdate={onUpdate} />
       </Row>
     </>
   )

--- a/packages/plugin-spring/src/spring-plugin.ts
+++ b/packages/plugin-spring/src/spring-plugin.ts
@@ -37,4 +37,5 @@ export const normalize = (input: SpringInput) => {
   }
 }
 
-export const sanitize = (value: InternalSpring, settings: InternalSpringSettings) => sanitizeVector(value, settings)
+export const sanitize = (value: InternalSpring, settings: InternalSpringSettings, prevValue?: any) =>
+  sanitizeVector(value, settings, prevValue)

--- a/packages/plugin-spring/src/spring-plugin.ts
+++ b/packages/plugin-spring/src/spring-plugin.ts
@@ -24,14 +24,16 @@ export type Plugin<Input, Value = Input, Settings = {}, InternalSettings = {}> =
 }
 
 export const normalize = (input: SpringInput) => {
-  const { value, ..._settings } = 'value' in input ? input : { value: input }
-  const settings = {
+  const { value: _value, ..._settings } = 'value' in input ? input : { value: input }
+  const mergedSettings = {
     tension: { ...defaultTensionSettings, ..._settings.tension },
     friction: { ...defaultFrictionSettings, ..._settings.friction },
     mass: { ...defaultMassSettings, ..._settings.mass },
   }
 
-  return normalizeVector({ ...defaultValue, ...value }, settings) as {
+  const { value, settings } = normalizeVector({ ...defaultValue, ..._value }, mergedSettings)
+
+  return { value, settings: { ...settings, lock: undefined } } as {
     value: InternalSpring
     settings: InternalSpringSettings
   }

--- a/packages/plugin-spring/src/spring-plugin.ts
+++ b/packages/plugin-spring/src/spring-plugin.ts
@@ -31,12 +31,7 @@ export const normalize = (input: SpringInput) => {
     mass: { ...defaultMassSettings, ..._settings.mass },
   }
 
-  const { value, settings } = normalizeVector({ ...defaultValue, ..._value }, mergedSettings)
-
-  return { value, settings: { ...settings, lock: undefined } } as {
-    value: InternalSpring
-    settings: InternalSpringSettings
-  }
+  return normalizeVector({ ...defaultValue, ..._value }, mergedSettings)
 }
 
 export const sanitize = (value: InternalSpring, settings: InternalSpringSettings, prevValue?: any) =>


### PR DESCRIPTION
First commit allows Vectors to be updated with only one of their keys.

<img width="273" alt="image" src="https://user-images.githubusercontent.com/5003380/109421914-9cc5b980-79d9-11eb-8815-8e2a7c3d7119.png">

API: 

```js
useControls({ vector: { value: [3, 4], lock: true }})
```

Edit: this commit also allows for math evaluation in number inputs!