### PR TITLE
Styles: minor amends on styles

### DIFF
--- a/demo/src/sandboxes/leva-theme/src/App.jsx
+++ b/demo/src/sandboxes/leva-theme/src/App.jsx
@@ -177,13 +177,13 @@ export default function App() {
           overflow: 'auto',
           background: '#181C20',
         }}>
-        <LevaPanel store={colorsStore} />
-        <LevaPanel store={radiiStore} />
-        <LevaPanel store={spaceStore} />
-        <LevaPanel store={fontSizesStore} />
-        <LevaPanel store={sizesStore} />
-        <LevaPanel store={borderWidthsStore} />
-        <LevaPanel store={fontWeightsStore} />
+        <LevaPanel fill flat hideTitleBar store={colorsStore} />
+        <LevaPanel fill flat hideTitleBar store={radiiStore} />
+        <LevaPanel fill flat hideTitleBar store={spaceStore} />
+        <LevaPanel fill flat hideTitleBar store={fontSizesStore} />
+        <LevaPanel fill flat hideTitleBar store={sizesStore} />
+        <LevaPanel fill flat hideTitleBar store={borderWidthsStore} />
+        <LevaPanel fill flat hideTitleBar store={fontWeightsStore} />
       </div>
       <Controls />
     </div>
@@ -196,9 +196,9 @@ export function App4() {
     minmax: {
       value: 10.5,
       min: 5.5,
-      max: 30.5
-    }
+      max: 30.5,
+    },
   })
-  
+
   return <pre>{JSON.stringify(x, null, '  ')}</pre>
 }

--- a/demo/src/sandboxes/leva-ui/src/App.jsx
+++ b/demo/src/sandboxes/leva-ui/src/App.jsx
@@ -142,8 +142,8 @@ export default function App() {
         ))}
       </div>
       <div className="panel">
-        <Leva detached={false} hideTitleBar />
-        <LevaPanel store={store} />
+        <Leva fill flat hideTitleBar />
+        <LevaPanel store={store} fill flat hideTitleBar />
       </div>
     </div>
   )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,8 @@ export default function MyApp() {
     <>
       <Leva
         theme={myTheme}  // you can pass a custom theme (see the styling section)
-        detached         // default = true,  false would make the pane fill the parent dom node it's rendered in.
+        fill             // default = false,  true makes the pane fill the parent dom node it's rendered in
+        flat             // default = false,  true removes border radius and shadow
         oneLineLabels    // default = false, alternative layout for labels, with labels and fields on separate rows  
         hideTitleBar     // default = false, hides the GUI header
         collapsed        // default = false, when true the GUI is collpased

--- a/packages/leva/src/components/Folder/Folder.tsx
+++ b/packages/leva/src/components/Folder/Folder.tsx
@@ -24,13 +24,20 @@ const Folder = ({ name, path, tree }: FolderProps) => {
   )
 }
 
-type TreeWrapperProps = { isRoot?: boolean; detached?: boolean; parent?: string; tree: Tree; toggled: boolean }
+type TreeWrapperProps = {
+  isRoot?: boolean
+  fill?: boolean
+  flat?: boolean
+  parent?: string
+  tree: Tree
+  toggled: boolean
+}
 
 export const TreeWrapper = React.memo(
-  ({ isRoot = false, detached = false, parent, tree, toggled }: TreeWrapperProps) => {
+  ({ isRoot = false, fill = false, flat = false, parent, tree, toggled }: TreeWrapperProps) => {
     const { wrapperRef, contentRef } = useToggle(toggled)
     return (
-      <StyledWrapper ref={wrapperRef} isRoot={isRoot} detached={detached} toggled={toggled}>
+      <StyledWrapper ref={wrapperRef} isRoot={isRoot} fill={fill} flat={flat} toggled={toggled}>
         <StyledContent ref={contentRef} isRoot={isRoot} toggled={toggled}>
           {Object.entries(tree).map(([key, value]) =>
             isInput(value) ? (

--- a/packages/leva/src/components/Folder/StyledFolder.ts
+++ b/packages/leva/src/components/Folder/StyledFolder.ts
@@ -41,7 +41,7 @@ export const StyledTitle = styled('div', {
   userSelect: 'none',
   cursor: 'pointer',
   marginTop: '$rowGap',
-  height: '$folderHeight',
+  height: '$folderTitleHeight',
   fontWeight: '$folder',
   '> svg': {
     marginLeft: -4,

--- a/packages/leva/src/components/Folder/StyledFolder.ts
+++ b/packages/leva/src/components/Folder/StyledFolder.ts
@@ -5,14 +5,17 @@ export const StyledFolder = styled('div', {})
 export const StyledWrapper = styled('div', {
   position: 'relative',
   background: '$elevation2',
-  transition: 'height 350ms ease',
+  transition: 'height 300ms ease',
   variants: {
-    detached: {
-      true: {
-        borderRadius: '$lg',
+    fill: {
+      false: {
         overflowY: 'auto',
-        maxHeight: 'calc(100vh - 20px - 43px)',
+        // 20px accounts for top margin
+        maxHeight: 'calc(100vh - 20px - $titleBarHeight)',
       },
+    },
+    flat: {
+      false: { borderRadius: '$lg' },
     },
     isRoot: {
       false: {

--- a/packages/leva/src/components/Leva/Leva.tsx
+++ b/packages/leva/src/components/Leva/Leva.tsx
@@ -9,15 +9,7 @@ let rootEl: HTMLDivElement | null = null
 type LevaProps = Omit<Partial<LevaRootProps>, 'store'> & { isRoot?: boolean }
 
 // uses global store
-export function Leva({
-  theme,
-  isRoot = false,
-  detached = true,
-  collapsed = false,
-  oneLineLabels = false,
-  hideTitleBar = false,
-  hidden = false,
-}: LevaProps) {
+export function Leva({ isRoot = false, ...props }: LevaProps) {
   useEffect(() => {
     rootInitialized = true
     // if this panel was attached somewhere in the app and there is already
@@ -31,17 +23,7 @@ export function Leva({
     }
   }, [isRoot])
 
-  return (
-    <LevaRoot
-      store={levaStore}
-      theme={theme}
-      detached={detached}
-      oneLineLabels={oneLineLabels}
-      hideTitleBar={hideTitleBar}
-      collapsed={collapsed}
-      hidden={hidden}
-    />
-  )
+  return <LevaRoot store={levaStore} {...props} />
 }
 
 /**

--- a/packages/leva/src/components/Leva/LevaPanel.tsx
+++ b/packages/leva/src/components/Leva/LevaPanel.tsx
@@ -5,26 +5,8 @@ import { LevaRoot, LevaRootProps } from './LevaRoot'
 type LevaPanelProps = Partial<LevaRootProps>
 
 // uses custom store
-export function LevaPanel({
-  store,
-  theme,
-  detached = false,
-  collapsed = false,
-  oneLineLabels = false,
-  hideTitleBar,
-  hidden = false,
-}: LevaPanelProps) {
+export function LevaPanel({ store, ...props }: LevaPanelProps) {
   const parentStore = useStoreContext()
   const _store = store === undefined ? parentStore : store
-  return (
-    <LevaRoot
-      store={_store}
-      theme={theme}
-      detached={detached}
-      oneLineLabels={oneLineLabels}
-      hideTitleBar={hideTitleBar ?? !detached}
-      collapsed={collapsed}
-      hidden={hidden}
-    />
-  )
+  return <LevaRoot store={_store} {...props} />
 }

--- a/packages/leva/src/components/Leva/LevaRoot.tsx
+++ b/packages/leva/src/components/Leva/LevaRoot.tsx
@@ -11,13 +11,38 @@ import { TitleWithFilter } from './Filter'
 import { StoreType } from '../../types'
 
 export type LevaRootProps = {
+  /**
+   * Theme with Stitches tokens
+   */
   theme?: LevaCustomTheme
+  /**
+   * The store to be used by the panel
+   */
   store?: StoreType | null
+  /**
+   * If true, won't display the panel
+   */
   hidden?: boolean
-  detached: boolean
-  collapsed: boolean
-  oneLineLabels: boolean
-  hideTitleBar: boolean
+  /**
+   * If true, the panel will fill its parent
+   */
+  fill?: boolean
+  /**
+   * If true, the panel will have no border radius nor shadow
+   */
+  flat?: boolean
+  /**
+   * If true, the panel will start collapsed
+   */
+  collapsed?: boolean
+  /**
+   * If true, input labels will stand above the controls
+   */
+  oneLineLabels?: boolean
+  /**
+   * If true, the title bar including filters and drag zone will be hidden
+   */
+  hideTitleBar?: boolean
 }
 
 export function LevaRoot({ store, hidden = false, theme, ...props }: LevaRootProps) {
@@ -31,37 +56,48 @@ export function LevaRoot({ store, hidden = false, theme, ...props }: LevaRootPro
   )
 }
 
-type LevaCoreProps = Omit<LevaRootProps, 'theme'> & { store: StoreType; rootClass: string }
+type LevaCoreProps = Omit<LevaRootProps, 'theme' | 'hidden'> & { store: StoreType; rootClass: string }
 
-const LevaCore = React.memo(({ store, rootClass, detached, collapsed, oneLineLabels, hideTitleBar }: LevaCoreProps) => {
-  const paths = useVisiblePaths(store)
-  const [filter, setFilter] = useState('')
-  const tree = useMemo(() => buildTree(paths, filter), [paths, filter])
+const LevaCore = React.memo(
+  ({
+    store,
+    rootClass,
+    fill = false,
+    flat = false,
+    collapsed = false,
+    oneLineLabels = false,
+    hideTitleBar = false,
+  }: LevaCoreProps) => {
+    const paths = useVisiblePaths(store)
+    const [filter, setFilter] = useState('')
+    const tree = useMemo(() => buildTree(paths, filter), [paths, filter])
 
-  // drag
-  const [rootRef, set] = useTransform<HTMLDivElement>()
+    // drag
+    const [rootRef, set] = useTransform<HTMLDivElement>()
 
-  // collapsible
-  const [toggled, setToggle] = useState(!collapsed)
+    // collapsible
+    const [toggled, setToggle] = useState(!collapsed)
 
-  // this generally happens on first render because the store is initialized in useEffect.
-  const shouldShow = paths.length > 0
+    // this generally happens on first render because the store is initialized in useEffect.
+    const shouldShow = paths.length > 0
 
-  return (
-    <StyledRoot
-      ref={rootRef}
-      className={rootClass}
-      detached={detached}
-      oneLineLabels={oneLineLabels}
-      style={{ display: shouldShow ? 'block' : 'none' }}>
-      {!hideTitleBar && (
-        <TitleWithFilter onDrag={set} setFilter={setFilter} toggle={() => setToggle((t) => !t)} toggled={toggled} />
-      )}
-      {shouldShow && (
-        <StoreContext.Provider value={store}>
-          <TreeWrapper isRoot detached={detached} tree={tree} toggled={toggled} />
-        </StoreContext.Provider>
-      )}
-    </StyledRoot>
-  )
-})
+    return (
+      <StyledRoot
+        ref={rootRef}
+        className={rootClass}
+        fill={fill}
+        flat={flat}
+        oneLineLabels={oneLineLabels}
+        style={{ display: shouldShow ? 'block' : 'none' }}>
+        {!hideTitleBar && (
+          <TitleWithFilter onDrag={set} setFilter={setFilter} toggle={() => setToggle((t) => !t)} toggled={toggled} />
+        )}
+        {shouldShow && (
+          <StoreContext.Provider value={store}>
+            <TreeWrapper isRoot fill={fill} flat={flat} tree={tree} toggled={toggled} />
+          </StoreContext.Provider>
+        )}
+      </StyledRoot>
+    )
+  }
+)

--- a/packages/leva/src/components/Leva/StyledFilter.ts
+++ b/packages/leva/src/components/Leva/StyledFilter.ts
@@ -19,7 +19,7 @@ export const StyledTitleWithFilter = styled('div', {
   display: 'flex',
   alignItems: 'stretch',
   justifyContent: 'space-between',
-  height: 43,
+  height: '$titleBarHeight',
   cursor: 'grab',
 })
 

--- a/packages/leva/src/components/Leva/StyledLeva.ts
+++ b/packages/leva/src/components/Leva/StyledLeva.ts
@@ -10,19 +10,23 @@ export const StyledRoot = styled('div', {
   backgroundColor: '$elevation1',
 
   variants: {
-    detached: {
-      true: {
+    fill: {
+      false: {
         position: 'fixed',
         top: '10px',
         right: '10px',
-        width: '$rootWidth',
-        borderRadius: '$lg',
-        boxShadow: '$level1',
         zIndex: 1000,
+        width: '$rootWidth',
       },
-      false: {
+      true: {
         position: 'relative',
         width: '100%',
+      },
+    },
+    flat: {
+      false: {
+        borderRadius: '$lg',
+        boxShadow: '$level1',
       },
     },
     oneLineLabels: {

--- a/packages/leva/src/styles/stitches.config.ts
+++ b/packages/leva/src/styles/stitches.config.ts
@@ -41,7 +41,7 @@ export const getDefaultTheme = () => ({
     scrubberWidth: '8px',
     scrubberHeight: '16px',
     rowHeight: '24px',
-    folderHeight: '20px',
+    folderTitleHeight: '20px',
     checkboxSize: '16px',
     joystickWidth: '100px',
     joystickHeight: '100px',

--- a/packages/leva/src/styles/stitches.config.ts
+++ b/packages/leva/src/styles/stitches.config.ts
@@ -50,6 +50,7 @@ export const getDefaultTheme = () => ({
     imagePreviewWidth: '$controlWidth',
     imagePreviewHeight: '100px',
     monitorHeight: '60px',
+    titleBarHeight: '39px',
   },
   shadows: {
     level1: '0 0 9px 0 #00000088',

--- a/packages/leva/stories/panel-options.stories.tsx
+++ b/packages/leva/stories/panel-options.stories.tsx
@@ -32,5 +32,8 @@ OneLineLabels.args = { oneLineLabels: true }
 export const HideTitleBar = Template.bind({})
 HideTitleBar.args = { hideTitleBar: true }
 
-export const NotDetached = Template.bind({})
-NotDetached.args = { detached: false }
+export const Fill = Template.bind({})
+Fill.args = { fill: true }
+
+export const Flat = Template.bind({})
+Flat.args = { flat: true }


### PR DESCRIPTION
This PR aims at giving more flexibility when it comes to using the Leva panel inside a parent node.

```jsx
<Leva
  theme={myTheme}  // you can pass a custom theme (see the styling section)
  fill             // default = false,  true makes the pane fill the parent dom node it's rendered in
  flat             // default = false,  true removes border radius and shadow
  oneLineLabels    // default = false, alternative layout for labels, with labels and fields on separate rows  
  hideTitleBar     // default = false, hides the GUI header
  collapsed        // default = false, when true the GUI is collpased
  hidden           // default = false, when true the GUI is hidden
/>
```