### PR TITLE
fix slider position overflow

### DIFF
--- a/.changeset/thin-cougars-attack.md
+++ b/.changeset/thin-cougars-attack.md
@@ -1,0 +1,5 @@
+---
+"leva": patch
+---
+
+fix: slider position overflowing with range input.

--- a/packages/leva/src/components/Number/RangeSlider.tsx
+++ b/packages/leva/src/components/Number/RangeSlider.tsx
@@ -32,7 +32,7 @@ export function RangeSlider({ value, min, max, onDrag, step, initialValue }: Ran
   return (
     <RangeWrapper ref={ref} {...bind()}>
       <Range>
-        <Indicator style={{ left: 0, right: `calc(${1 - pos} * (100% - ${scrubberWidth}))` }} />
+        <Indicator style={{ left: 0, right: `${(1 - pos) * 100}%` }} />
       </Range>
       <Scrubber ref={scrubberRef} style={{ left: `calc(${pos} * (100% - ${scrubberWidth}))` }} />
     </RangeWrapper>


### PR DESCRIPTION
Hi, this is another small fix

I have fixed this annoying glitch with slider. It happens on some values and probably this is browser calc rounding miss

before
<img width="298" alt="Снимок экрана 2021-03-25 в 12 41 02" src="https://user-images.githubusercontent.com/6726016/112452308-8ce68e80-8d67-11eb-8c55-010255e7ec1a.png">


after
<img width="298" alt="Снимок экрана 2021-03-25 в 12 42 04" src="https://user-images.githubusercontent.com/6726016/112452324-9112ac00-8d67-11eb-9604-1e7826b71421.png">

