### PR TITLE
Fix/refactor options

### DIFF
--- a/.changeset/eighty-shoes-protect.md
+++ b/.changeset/eighty-shoes-protect.md
@@ -1,0 +1,5 @@
+---
+'leva': patch
+---
+
+feat: allow input options to be spread inside custom plugin.

--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -36,6 +36,7 @@ function Controls() {
   const data = useControls({
     range: { value: 0, min: -10, max: 10 },
     dimension: '4px',
+    string: 'something',
     image: { image: undefined },
     select: { options: ['x', 'y', ['x', 'y']] },
     interval: { min: -100, max: 100, value: [-10, 10] },

--- a/demo/src/sandboxes/leva-plugin-bezier/src/App.tsx
+++ b/demo/src/sandboxes/leva-plugin-bezier/src/App.tsx
@@ -6,6 +6,9 @@ import './style.css'
 export default function App() {
   const { curve } = useControls({ curve: bezier() })
 
+  //const a = [...curve]
+  console.log(...curve)
+
   return (
     <div className="App">
       <div className="bezier-animated" style={{ animationTimingFunction: curve.cssEasing }} />

--- a/demo/src/sandboxes/leva-plugin-spring/src/App.tsx
+++ b/demo/src/sandboxes/leva-plugin-spring/src/App.tsx
@@ -4,7 +4,7 @@ import { spring } from '@leva-ui/plugin-spring'
 
 export default function App() {
   const { mySpring } = useControls({
-    mySpring: { ...spring({ tension: 100, friction: 30 }), hint: 'spring to use with react-spring' },
+    mySpring: spring({ tension: 100, friction: 30, hint: 'spring to use with react-spring' }),
   })
 
   return (

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -25,24 +25,27 @@ export type StoreType = {
   getDataFromSchema: (schema: any) => [Data, MappedPaths]
 }
 
-type Decorators = {
-  __refCount: number
+export type CommonOptions = {
   key: string
   label: string | JSX.Element
   hint?: string
   render?: RenderFn
 }
 
-export type DataInput = {
-  type: string
-  value: unknown
+export type DataInputOptions = CommonOptions & {
   optional: boolean
   disabled: boolean
   onChange?: (value: unknown) => void
-  settings?: object
-} & Decorators
+}
 
-export type DataItem = DataInput | (SpecialInput & Decorators)
+export type DataInput = {
+  __refCount: number
+  type: string
+  value: unknown
+  settings?: object
+} & DataInputOptions
+
+export type DataItem = DataInput | (SpecialInput & CommonOptions & { __refCount: number })
 
 export type Data = Record<string, DataItem>
 

--- a/packages/leva/src/types/public.ts
+++ b/packages/leva/src/types/public.ts
@@ -150,7 +150,7 @@ export type Schema = Record<string, SchemaItemWithOptions>
 type NotAPrimitiveType = { ____: 'NotAPrimitiveType' }
 
 type PrimitiveToValue<S> = S extends CustomInput<infer I>
-  ? I
+  ? BeautifyUnionType<I>
   : S extends ImageInput
   ? string | undefined
   : S extends SelectWithValueInput<infer T, infer K>
@@ -188,7 +188,7 @@ export type Leaves<IncludeTransient extends boolean, T, P extends string | numbe
   1: never
   // if the leaf is an object, we run the type check on each of its keys
   2: {
-    [i in P]: BeautifyUnionType<T extends { optional: true } ? PrimitiveToValue<T> | undefined : PrimitiveToValue<T>>
+    [i in P]: T extends { optional: true } ? PrimitiveToValue<T> | undefined : PrimitiveToValue<T>
   }
   // recursivity
   3: { [K in keyof T]: Join<T, K, Leaves<IncludeTransient, T[K], K>> }[keyof T]

--- a/packages/leva/src/types/utils.ts
+++ b/packages/leva/src/types/utils.ts
@@ -1,5 +1,4 @@
 // Utils from https://github.com/pmndrs/use-tweaks/blob/92561618abbf43c581fc5950fd35c0f8b21047cd/src/types.ts#L70
-
 /**
  * It does nothing but beautify union type
  *
@@ -11,8 +10,10 @@
 export type BeautifyUnionType<T> = T extends Function
   ? T
   : T extends infer TT
-  ? { [k in keyof TT]: TT[k] } & IterableIterator<T> // adds Iterator to the return type in case it has any
+  ? { [k in keyof TT]: TT[k] } & GetIterator<TT> // adds Iterator to the return type in case it has any
   : never
+
+type GetIterator<T> = T extends { [Symbol.iterator]: any } ? IterableIterator<T> : {}
 
 export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
 

--- a/packages/leva/src/utils/input.ts
+++ b/packages/leva/src/utils/input.ts
@@ -1,7 +1,53 @@
 import { dequal } from 'dequal/lite'
 import { getValueType, normalize, sanitize } from '../plugin'
-import { Data, DataInput, SpecialInputs, StoreType } from '../types'
-import { warn, LevaErrors } from './log'
+import { CommonOptions, Data, DataInput, DataInputOptions, SpecialInputs, StoreType } from '../types'
+
+type ParsedOptions = {
+  type?: string
+  input: any
+  options: CommonOptions | DataInputOptions
+}
+
+export function parseOptions(_input: any, key: string, customType?: string): ParsedOptions {
+  if (typeof _input !== 'object' || Array.isArray(_input)) {
+    return {
+      type: customType,
+      input: _input,
+      options: {
+        key,
+        label: key,
+        optional: false,
+        disabled: false,
+      },
+    }
+  }
+
+  if ('__customInput' in _input) {
+    return parseOptions(_input.__customInput, key, _input.type)
+  }
+
+  // parse generic options from input object
+  const { render, label, optional, disabled, hint, onChange, ...inputWithType } = _input
+  const commonOptions = { render, key, label: label ?? key, hint }
+
+  let { type, ...input } = inputWithType
+  type = customType ?? type
+
+  if (type in SpecialInputs) {
+    return { type, input, options: commonOptions }
+  }
+
+  return {
+    type,
+    input,
+    options: {
+      ...commonOptions,
+      onChange,
+      optional: optional ?? false,
+      disabled: disabled ?? false,
+    },
+  }
+}
 
 /**
  * This function is used to normalize the way an input is stored in the store.
@@ -11,29 +57,28 @@ import { warn, LevaErrors } from './log'
  * @param input
  * @param path
  */
-export function normalizeInput(input: any, path: string, data: Data) {
-  if (typeof input === 'object') {
-    if ('type' in input) {
+export function normalizeInput(_input: any, key: string, path: string, data: Data) {
+  const parsedInputAndOptions = parseOptions(_input, key)
+  const { type, input: parsedInput, options } = parsedInputAndOptions
+
+  if (type) {
+    if (type in SpecialInputs)
       // If the input is a special input then we return it as it is.
-      if (input.type in SpecialInputs) return input
+      return parsedInputAndOptions
 
-      // If the type key exists at this point, it must be a custom plugin
-      // defined by the user.
-      const { type, ...rest } = input
-      const _input = 'value' in rest ? rest.value : rest
-      return { type, ...normalize(type, _input, path, data) }
-    }
-    const type = getValueType(input)
-    if (type) return { type, ...normalize(type, input, path, data) }
+    // If the type key exists at this point, it must be a custom plugin
+    // defined by the user, and it's already been normalized.
+    return { type, input: normalize(type, parsedInput, path, data), options }
   }
+  let inputType = getValueType(parsedInput)
+  if (inputType) return { type: inputType, input: normalize(inputType, parsedInput, path, data), options }
 
-  const type = getValueType({ value: input })
+  inputType = getValueType({ value: parsedInput })
 
-  // At this point, if type is null we'll have to warn the user that its input
-  // is not recognized.
-  if (!type) return warn(LevaErrors.UNKNOWN_INPUT, path, input)
+  if (inputType) return { type: inputType, input: normalize(inputType, { value: parsedInput }, path, data), options }
 
-  return { type, ...normalize(type, { value: input }, path, data) }
+  // At this point, the input is not recognized and we return false
+  return false
 }
 
 export function updateInput(input: DataInput, newValue: any, path: string, store: StoreType) {

--- a/packages/leva/src/utils/input.ts
+++ b/packages/leva/src/utils/input.ts
@@ -9,6 +9,7 @@ type ParsedOptions = {
 }
 
 export function parseOptions(_input: any, key: string, mergedOptions = {}, customType?: string): ParsedOptions {
+  // if input isn't an object then we just need to assing default options to it.
   if (typeof _input !== 'object' || Array.isArray(_input)) {
     return {
       type: customType,
@@ -23,6 +24,8 @@ export function parseOptions(_input: any, key: string, mergedOptions = {}, custo
     }
   }
 
+  // if it's a custom input, then the input will be under the __customInput key
+  // so we run the parseOptions function on that key and for its type.
   if ('__customInput' in _input) {
     /**
      * If a custom input uses a non object arg, the only way to parse options

--- a/packages/plugin-bezier/src/Bezier.stories.tsx
+++ b/packages/plugin-bezier/src/Bezier.stories.tsx
@@ -32,4 +32,4 @@ export const WithPreset = Template.bind({})
 WithPreset.args = bezier('in-out-quadratic')
 
 export const WithOptions = Template.bind({})
-WithOptions.args = bezier({ handles: [0.54, 0.05, 0.6, 0.98], graph: false })
+WithOptions.args = bezier({ handles: [0.54, 0.05, 0.6, 0.98], graph: false, label: 'no graph' })


### PR DESCRIPTION
Full rewrite of how options are parsed and fix some types with custom plugins.

```js
// before
useControls({ spring: {...spring({ tension: 100 }), label: 'mySpring' })

// after
useControls({ spring: spring({ tension: 100, label: 'mySpring' })
```

