### PR TITLE
refactor(leva): export the InputContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ function MyComponent() {
 
 - [Advanced: Controlled Inputs](/docs/advanced/controlled-inputs.md)
 - [Advanced: Creating Plugins](/docs/advanced/creating-plugins.md)
+- [Advanced: Custom UI](/docs/advanced/custom-ui.md)
 
 
 ## Contributors ✨

--- a/docs/advanced/custom-ui.md
+++ b/docs/advanced/custom-ui.md
@@ -1,10 +1,10 @@
 # Creating Custom UI
 
-Incase if you need to use leva as backbone for your custom UI needs here is an approach
+This guide will walk you through how to use leva as the backbone of your UI while briging your own components.
 
 ## Setup store provider
 
-First we will create a StoreProvider which will take care of creating an instance of store and providing it
+First we will create a `StoreProvider` which will take care of creating an instance of the store and providing it to the children:
 
 
 ```tsx
@@ -32,7 +32,7 @@ First we will create a StoreProvider which will take care of creating an instanc
 
 ## Creating Wrapper Control Input
 
-Now lets create a wrapper control input component that we can use to wrap our controls so that we can access the helper methods using the provided hooks
+Now we create a wrapper control input component that we can use to wrap our controls so that we can access the helper methods using the provided hooks:
 
 ```tsx
     import { InputContextProvider } from 'leva'

--- a/docs/advanced/custom-ui.md
+++ b/docs/advanced/custom-ui.md
@@ -1,0 +1,97 @@
+# Creating Custom UI
+
+Incase if you need to use leva as backbone for your custom UI needs here is an approach
+
+## Setup store provider
+
+First we will create a StoreProvider which will take care of creating an instance of store and providing it
+
+
+```tsx
+    import { LevaStoreProvider } from 'leva'
+
+    const StoreProvider  = ( { children, schema } ) => {
+        const store = useCreateStore()
+
+        // We initialize the store
+        // Using the schema that was passed in
+        useEffect( ( ) => {
+            
+            // Get the initial data for the passed schema
+            const [ initialData ] = store.getDataFromSchema( schema )
+            // Add the data to the store
+            store.addData( initialData, true )
+            
+        }, [ store, schema ] )
+
+        return (
+            <LevaStoreProvider store={store} children={children}>
+        )
+    }
+```
+
+## Creating Wrapper Control Input
+
+Now lets create a wrapper control input component that we can use to wrap our controls so that we can access the helper methods using the provided hooks
+
+```tsx
+    import { InputContextProvider } from 'leva'
+
+    const ControlInput = ( { path, children, ...rest } ) => {
+        const [
+            input,
+            { set, settings }
+        ] = useInput( path )
+        const { type, label, key, ...inputProps } = input
+        const { displayValue, onChange, onUpdate } = useInputSetters({ type, value, settings, setValue: set })
+
+        return (
+            <InputContextProvider value={{
+                key,
+                path,
+                label,
+                displayValue,
+                value,
+                onChange,
+                onUpdate,
+                setValue: set,
+                ...rest
+            }}>
+                { children }
+            </InputContextProvider>
+        )
+    }
+```
+
+# Your own component
+
+```tsx
+    import { useInputContext } from 'leva'
+
+    const MyBooleanComponent = ( ) => {
+        const {
+            label,
+            onChange
+        } = useInputContext()
+
+        return (
+            <checkbox label={label} onChange={onChange} />
+        )
+    }
+```
+
+## Using your component
+
+Now that we have everything ready lets wire everything up
+
+```tsx
+    const Application = ( ) => {
+
+        return (
+            <StoreProvider>
+                <MyBooleanComponent />
+            </StoreProvider>
+        )
+        
+    }
+```

--- a/packages/leva/src/context.tsx
+++ b/packages/leva/src/context.tsx
@@ -32,3 +32,16 @@ type LevaStoreProviderProps = {
 export function LevaStoreProvider({ children, store }: LevaStoreProviderProps) {
   return <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
 }
+
+type InputContextProvider = {
+    children: React.ReactChild | React.ReactChild[] | React.ReactChildren
+    value: any
+}
+
+export function InputContextProvider ( { children, value }: InputContextProvider ) {
+    return (
+        <InputContext.Provider value={value}>
+            { children }
+        </InputContext.Provider>
+    )
+}

--- a/packages/leva/src/index.ts
+++ b/packages/leva/src/index.ts
@@ -32,7 +32,7 @@ export { useControls } from './useControls'
 export { Leva, LevaPanel } from './components/Leva'
 
 // simplifies passing store as context
-export { useStoreContext, LevaStoreProvider, InputContext } from './context'
+export { useStoreContext, LevaStoreProvider, InputContextProvider } from './context'
 
 // export the levaStore (default store)
 // hook to create custom store

--- a/packages/leva/src/index.ts
+++ b/packages/leva/src/index.ts
@@ -32,7 +32,7 @@ export { useControls } from './useControls'
 export { Leva, LevaPanel } from './components/Leva'
 
 // simplifies passing store as context
-export { useStoreContext, LevaStoreProvider } from './context'
+export { useStoreContext, LevaStoreProvider, InputContext } from './context'
 
 // export the levaStore (default store)
 // hook to create custom store


### PR DESCRIPTION
In reference to this issue #265 

In scenarios where some one wants to use leva as backbone with their own custom UI. We would need the InputContext to be exposed.
