### PR TITLE
Run eslint and prettier on all files in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Check types
         run: yarn tsc
 
+      - name: Check formatting
+        run: yarn prettier
+
+      - name: Lint files
+        run: yarn lint:full
+
       - uses: actions/cache@v2
         name: Setup Yarn build cache
         id: yarn-build-cache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint
+npm run lint

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "demo:build": "yarn workspace demo build",
     "demo:serve": "yarn workspace demo serve",
     "ci:test": "yarn demo:build && start-server-and-test demo:serve http-get://localhost:5000 cypress:run",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prettier": "prettier --check ."
   },
   "size-limit": [
     {


### PR DESCRIPTION
This will fail until #273 is merged with all the prettier changes.

Also, use `npm` in pre-commit hook for those of us without yarn (and in the future pnpm) globally installed.
