### PR TITLE
docs: output theme json in leva-theme example

### DIFF
--- a/demo/src/sandboxes/leva-theme/src/App.jsx
+++ b/demo/src/sandboxes/leva-theme/src/App.jsx
@@ -168,7 +168,8 @@ export default function App() {
           width: 300,
           gap: 10,
           paddingBottom: 40,
-          overflow: 'auto',
+          marginRight: 10,
+          float: 'left',
           background: '#181C20',
         }}>
         <LevaPanel fill flat titleBar={false} store={colorsStore} />
@@ -179,6 +180,7 @@ export default function App() {
         <LevaPanel fill flat titleBar={false} store={borderWidthsStore} />
         <LevaPanel fill flat titleBar={false} store={fontWeightsStore} />
       </div>
+      <pre>{JSON.stringify(theme, null, '  ')}</pre>
       <Controls />
     </div>
   )


### PR DESCRIPTION
## Action: Puts the json in the page view so you can copy it out. 


### Reason: 

It seems like it may have bene used this way before with an additional component. 

Used float because I'm old and lazy.

fixes #318 

### Preview: 
<img width="600" alt="Screen Shot 2022-03-13 at 07 04 07" src="https://user-images.githubusercontent.com/1397052/158058687-8dcb4564-54a7-4251-b56e-a8a2314757a9.png">