### PR TITLE
Feature : custom user functions for the plot plugin interpreter.

### DIFF
--- a/packages/plugin-plot/src/Plot.stories.tsx
+++ b/packages/plugin-plot/src/Plot.stories.tsx
@@ -36,6 +36,16 @@ BoundsX.args = { expression: 'cos(x)', boundsX: [-10, 10] }
 export const BoundsY = Template.bind({})
 BoundsY.args = { expression: 'sin(x) * tan(x)', boundsX: [-10, 10], boundsY: [-1, 1] }
 
+export const ImportedFunc = Template.bind({})
+ImportedFunc.args = {
+  expression: 'mix(0, 1, x)',
+  imported: {
+    mix: (a: number, b: number, x: number) => {
+      return a + (b - a) * x
+    },
+  },
+}
+
 export const InputAsVariable = () => {
   const { y } = useControls({ var: 10, y: plot({ expression: 'cos(x * var)' }) })
   return (

--- a/packages/plugin-plot/src/plot-plugin.ts
+++ b/packages/plugin-plot/src/plot-plugin.ts
@@ -1,10 +1,11 @@
 import { Data, StoreType } from 'packages/leva/src/types'
 import * as math from 'mathjs'
-import { parseExpression } from './plot-utils'
+import { parseExpression, createInstance } from './plot-utils'
 import type { PlotInput, InternalPlot, InternalPlotSettings } from './plot-types'
 
 export const sanitize = (
   expression: string,
+  // _imported: ImportObject,
   _settings: InternalPlotSettings,
   _prevValue: math.MathNode,
   _path: string,
@@ -24,12 +25,13 @@ export const format = (value: InternalPlot) => {
 
 const defaultSettings = { boundsX: [-1, 1], boundsY: [-Infinity, Infinity], graph: true }
 
-export const normalize = ({ expression, ..._settings }: PlotInput, _path: string, data: Data) => {
+export const normalize = ({ expression, imported, ..._settings }: PlotInput, _path: string, data: Data) => {
   const get = (path: string) => {
     // @ts-expect-error
     if ('value' in data[path]) return data[path].value
     return undefined // TODO should throw
   }
+  createInstance(imported)
   const value = parseExpression(expression, get) as (v: number) => any
   const settings = { ...defaultSettings, ..._settings }
   return { value, settings: settings as InternalPlotSettings }

--- a/packages/plugin-plot/src/plot-types.ts
+++ b/packages/plugin-plot/src/plot-types.ts
@@ -1,6 +1,7 @@
 import type { LevaInputProps } from 'leva/plugin'
+import type { ImportObject } from 'mathjs'
 
-export type Plot = { expression: string }
+export type Plot = { expression: string; imported?: ImportObject }
 export type PlotSettings = { boundsX?: [number, number]; boundsY?: [number, number]; graph?: boolean }
 export type PlotInput = Plot & PlotSettings
 

--- a/packages/plugin-plot/src/plot-utils.ts
+++ b/packages/plugin-plot/src/plot-utils.ts
@@ -1,4 +1,13 @@
-import * as math from 'mathjs'
+import * as mathjs from 'mathjs'
+
+let math = mathjs
+
+export function createInstance(imported: ImportObject) {
+  math = mathjs.create(mathjs.all)
+  if (imported !== undefined) {
+    math.import(imported, {})
+  }
+}
 
 export function getSymbols(expr: math.MathNode) {
   return expr


### PR DESCRIPTION
Hey everyone,

So I'm interested into adding custom functions - like `smoothstep` - to the plot plugin using the [import function](https://mathjs.org/examples/import.js.html) of the underlying _mathjs_ library. 

Here is a proof of concept implementation which allow the user to provide an `imported` attribute to the plot function accepting a dictionnary of functions.

For example :
```typescript
plot( { 
  expression: 'mix(0, 1, x)',
  imported: {
    mix: (a: number, b: number, x: number) => {
      return a + (b - a) * x
    })
```

The idea is to define the functions in a general dictionnary once and pass it to a plot wrapper for the whole app, as each plot will instanciate mathjs before evaluation to import its custom functions (_a bit of a caveat I suppose_).

Here's a simplified clojurescript version of what I'm using for example :
```clojure
(def custom-mathjs-functions {:smoothstep #(.smoothstep THREE/MathUtils %3 %1 %1)})

(defn plot-expr
  [expr]
  (plot (clj->js {:expression expr
                  :boundsX [0 1] 
                  :boundsY [0 1]
                  :graph true
                  :imported custom-mathjs-functions})
```

So it might become cumbersome for larger functions library.