### PR TITLE
fix(leva): disabled labels not showing tooltips

### DIFF
--- a/.changeset/tender-walls-camp.md
+++ b/.changeset/tender-walls-camp.md
@@ -1,0 +1,5 @@
+---
+'leva': patch
+---
+
+Fixes an issue where tooltips for disabled inputs weren't being displayed

--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -48,6 +48,11 @@ function Controls() {
     color: '#ffffff',
     refMonitor: monitor(frame, { graph: true, interval: 30 }),
     number: { value: 1000, min: 3 },
+    disabled: {
+      value: 'A disabled input',
+      disabled: true,
+      hint: 'This input is disabled',
+    },
     colorObj: { value: { r: 1, g: 2, b: 3 }, render: (get) => get('folder.boolean') },
     folder: folder(
       {

--- a/packages/leva/src/components/UI/Label.tsx
+++ b/packages/leva/src/components/UI/Label.tsx
@@ -51,7 +51,7 @@ function RawLabel(props: LabelProps) {
 }
 
 export function Label({ align, ...props }: LabelProps & { align?: 'top' }) {
-  const { value, label, key } = useInputContext()
+  const { value, label, key, disabled } = useInputContext()
   const { hideCopyButton } = usePanelSettingsContext()
 
   const copyEnabled = !hideCopyButton && key !== undefined
@@ -70,7 +70,7 @@ export function Label({ align, ...props }: LabelProps & { align?: 'top' }) {
   return (
     <CopyLabelContainer align={align} onPointerLeave={() => setCopied(false)}>
       <RawLabel {...props} />
-      {copyEnabled && (
+      {copyEnabled && !disabled && (
         <div title={`Click to copy ${typeof label === 'string' ? label : key} value`}>
           {!copied ? (
             <svg onClick={handleClick} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">

--- a/packages/leva/src/components/UI/StyledUI.ts
+++ b/packages/leva/src/components/UI/StyledUI.ts
@@ -16,8 +16,17 @@ export const StyledRow = styled('div', {
     '&:last-of-type': { marginBottom: '$rowGap' },
   },
 
-  '&:hover,&:focus-within': {
-    color: '$highlight3',
+  variants: {
+    disabled: {
+      true: {
+        pointerEvents: 'none',
+      },
+      false: {
+        '&:hover,&:focus-within': {
+          color: '$highlight3',
+        },
+      },
+    },
   },
 })
 

--- a/packages/leva/src/components/UI/StyledUI.ts
+++ b/packages/leva/src/components/UI/StyledUI.ts
@@ -110,15 +110,6 @@ export const StyledOptionalToggle = styled('input', {
   },
 })
 
-export const StyledInputWrapper = styled('div', {
-  opacity: 1,
-  variants: {
-    disabled: {
-      true: { opacity: 0.6, pointerEvents: 'none' },
-    },
-  },
-})
-
 export const StyledLabel = styled('label', {
   fontWeight: '$label',
   overflow: 'hidden',
@@ -126,6 +117,19 @@ export const StyledLabel = styled('label', {
   whiteSpace: 'nowrap',
   '& > svg': {
     display: 'block', // fixes svg vertical misalignment
+  },
+})
+
+export const StyledInputWrapper = styled('div', {
+  opacity: 1,
+  variants: {
+    disabled: {
+      true: {
+        opacity: 0.6,
+        pointerEvents: 'none',
+        [`& ${StyledLabel}`]: { pointerEvents: 'auto' },
+      },
+    },
   },
 })
 


### PR DESCRIPTION
### Problem

As mentioned in #264 tooltips aren't being rendered on hover when the input is disabled.

This is due to pointer events being set to `none` by the `disabled` variant of `StyledInputWrapper`.

### Solution

- Add a `disabled` variant to `StyledRow` to conditionally remove pointer-events / apply hover styles
- Reset `StyledLabel` pointer-events when `StyledInputWrapper` is `disabled`
- Don't render the "copy" icon when the input is disabled

### Results

#### Before
![leva__disabled_tooltip__before](https://user-images.githubusercontent.com/8475441/166609922-be035827-ab82-4f61-98a2-da48adb6ae5f.gif)

#### After
![leva__disabled_tooltip__after](https://user-images.githubusercontent.com/8475441/166609925-d596bddd-c1f5-4c4b-841c-f346ecd4bbcb.gif)

