### PR TITLE
Fix/array based custom inputs

### DIFF
--- a/.changeset/weak-lies-travel.md
+++ b/.changeset/weak-lies-travel.md
@@ -1,0 +1,5 @@
+---
+'leva': patch
+---
+
+fix: support { value: input } for custom plugins that are not object-based

--- a/packages/leva/src/plugin.ts
+++ b/packages/leva/src/plugin.ts
@@ -52,7 +52,11 @@ export function createInternalPlugin<Input, Value, InternalSettings, Settings>(
   return plugin
 }
 
-type PluginInput<Input> = Input extends object ? Input & InputOptions : Input
+type PluginInput<Input> = Input extends object
+  ? Input extends Array<any>
+    ? Input | ({ value: Input } & InputOptions)
+    : Input & InputOptions
+  : Input
 
 /**
  * This function should be used by custom plugins. It is mostly used as a way

--- a/packages/leva/src/utils/input.ts
+++ b/packages/leva/src/utils/input.ts
@@ -1,4 +1,5 @@
 import { dequal } from 'dequal/lite'
+import { isObject, isEmptyObject } from '.'
 import { getValueType, normalize, sanitize } from '../plugin'
 import {
   CommonOptions,
@@ -75,9 +76,15 @@ export function parseOptions(
     return { type, input, options: commonOptions }
   }
 
+  // in case this is a custom input like beziers where the argument is an array,
+  // then the array could be passed as { value: [0,0,0,0], onChange: () => {} }.
+  let computedInput
+  if (customType && isObject(input) && 'value' in input) computedInput = input.value
+  else computedInput = isEmptyObject(input) ? undefined : input
+
   return {
     type,
-    input,
+    input: computedInput,
     options: {
       ...commonOptions,
       onChange,

--- a/packages/leva/src/utils/object.ts
+++ b/packages/leva/src/utils/object.ts
@@ -19,3 +19,5 @@ export function mapArrayToKeys<U extends any, K extends string>(value: U[], keys
 export function isObject(variable: any) {
   return Object.prototype.toString.call(variable) === '[object Object]'
 }
+
+export const isEmptyObject = (obj: Object) => isObject(obj) && Object.keys(obj).length === 0


### PR DESCRIPTION
This PR fixes the inability for custom plugins such as `bezier()` that accept an array as an argument to support common input options such as `onChange` or `optional`. Now we can have:

```js
useControls({
  myCurve: bezier({ value: [0, 0.25, 0.25, 1], optional: true })
})
```

Note that for object-based arguments, common options can be added as regular keys.

```js
useControls({
  mySpring: spring({ tension: 120, mass: 2, optional: true })
})
```