### PR TITLE
fix: move 'why-did-you-render' to devDependencies

### DIFF
--- a/packages/leva/package.json
+++ b/packages/leva/package.json
@@ -26,7 +26,6 @@
     "@radix-ui/react-tooltip": "0.1.6",
     "@stitches/react": "1.2.8",
     "@use-gesture/react": "^10.2.5",
-    "@welldone-software/why-did-you-render": "^6.2.3",
     "colord": "^2.9.2",
     "dequal": "^2.0.2",
     "merge-value": "^1.0.0",
@@ -34,5 +33,8 @@
     "react-dropzone": "^12.0.0",
     "v8n": "^1.3.3",
     "zustand": "^3.6.9"
+  },
+  "devDependencies": {
+    "@welldone-software/why-did-you-render": "^6.2.3"
   }
 }


### PR DESCRIPTION
Hey! Firstly, awesome work on Leva. Awesome package.

Fairly likely that this is providing some service that I've not managed to catch from a quick look through the code, but I can't see if there's a reason why `@welldone-software/why-did-you-render` is a production dependency rather than a dev dep? 🙂

Was throwing conflict warnings in a project so I thought I'd check and open this PR in case it was helpful!

