### PR TITLE
feat: `useControls`  returns a `get` function

### DIFF
--- a/.changeset/bright-moose-tap.md
+++ b/.changeset/bright-moose-tap.md
@@ -1,5 +1,5 @@
 ---
-'leva': patch
+'leva': minor
 ---
 
 feat: `useControls` returns a `get` function

--- a/.changeset/bright-moose-tap.md
+++ b/.changeset/bright-moose-tap.md
@@ -1,0 +1,5 @@
+---
+'leva': patch
+---
+
+feat: `useControls` returns a `get` function

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -14,9 +14,7 @@ type FunctionReturnType<S extends Schema, FOLDER extends string | void> = [
   (value: {
     [K in keyof Partial<SchemaToValues<S, true>>]: SchemaToValues<S, true>[K]
   }) => void,
-  <K extends string & keyof SchemaToValues<S, true>>(
-    path: FOLDER extends string ? `${FOLDER}.${K}` : K
-  ) => SchemaToValues<S, true>[K]
+  <T extends keyof SchemaToValues<S, true>>(path: T) => SchemaToValues<S, true>[T]
 ]
 
 type ReturnType<F extends SchemaOrFn, FOLDER extends string | void = void> = F extends SchemaOrFn<infer S>
@@ -184,7 +182,12 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
     [store, mappedPaths]
   )
 
-  const get = useMemo(() => store.get, [store])
+  const get = useCallback(
+    (path: string) => {
+      store.get(mappedPaths[path].path)
+    },
+    [store, mappedPaths]
+  )
 
   useEffect(() => {
     // We initialize the store with the initialData in useEffect.

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -9,22 +9,26 @@ import shallow from 'zustand/shallow'
 type HookSettings = { store?: StoreType }
 type SchemaOrFn<S extends Schema = Schema> = S | (() => S)
 
-type FunctionReturnType<S extends Schema> = [
+type FunctionReturnType<S extends Schema, FOLDER extends string | void> = [
   SchemaToValues<S>,
   (value: {
-    [K in keyof Partial<SchemaToValues<S, true>>]: any
+    [K in keyof Partial<SchemaToValues<S, true>>]: SchemaToValues<S, true>[K]
   }) => void,
-  <T extends keyof SchemaToValues<S, true>>(path: T) => SchemaToValues<S, true>[T]
+  <K extends string & keyof SchemaToValues<S, true>>(
+    path: FOLDER extends string ? `${FOLDER}.${K}` : K
+  ) => SchemaToValues<S, true>[K]
 ]
 
-type ReturnType<F extends SchemaOrFn> = F extends SchemaOrFn<infer S>
+type ReturnType<F extends SchemaOrFn, FOLDER extends string | void = void> = F extends SchemaOrFn<infer S>
   ? F extends Function
-    ? FunctionReturnType<S>
+    ? FunctionReturnType<S, FOLDER>
     : SchemaToValues<S>
   : never
 
 type HookReturnType<F extends SchemaOrFn | string, G extends SchemaOrFn> = F extends SchemaOrFn
   ? ReturnType<F>
+  : F extends string
+  ? ReturnType<G, F>
   : ReturnType<G>
 
 function parseArgs(

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -9,7 +9,7 @@ import shallow from 'zustand/shallow'
 type HookSettings = { store?: StoreType }
 type SchemaOrFn<S extends Schema = Schema> = S | (() => S)
 
-type FunctionReturnType<S extends Schema, FOLDER extends string | void> = [
+type FunctionReturnType<S extends Schema> = [
   SchemaToValues<S>,
   (value: {
     [K in keyof Partial<SchemaToValues<S, true>>]: SchemaToValues<S, true>[K]
@@ -17,16 +17,16 @@ type FunctionReturnType<S extends Schema, FOLDER extends string | void> = [
   <T extends keyof SchemaToValues<S, true>>(path: T) => SchemaToValues<S, true>[T]
 ]
 
-type ReturnType<F extends SchemaOrFn, FOLDER extends string | void = void> = F extends SchemaOrFn<infer S>
+type ReturnType<F extends SchemaOrFn> = F extends SchemaOrFn<infer S>
   ? F extends Function
-    ? FunctionReturnType<S, FOLDER>
+    ? FunctionReturnType<S>
     : SchemaToValues<S>
   : never
 
 type HookReturnType<F extends SchemaOrFn | string, G extends SchemaOrFn> = F extends SchemaOrFn
   ? ReturnType<F>
   : F extends string
-  ? ReturnType<G, F>
+  ? ReturnType<G>
   : ReturnType<G>
 
 function parseArgs(

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -25,8 +25,6 @@ type ReturnType<F extends SchemaOrFn> = F extends SchemaOrFn<infer S>
 
 type HookReturnType<F extends SchemaOrFn | string, G extends SchemaOrFn> = F extends SchemaOrFn
   ? ReturnType<F>
-  : F extends string
-  ? ReturnType<G>
   : ReturnType<G>
 
 function parseArgs(

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -13,7 +13,8 @@ type FunctionReturnType<S extends Schema> = [
   SchemaToValues<S>,
   (value: {
     [K in keyof Partial<SchemaToValues<S, true>>]: any
-  }) => void
+  }) => void,
+  <T extends keyof SchemaToValues<S, true>>(path: T) => SchemaToValues<S, true>[T]
 ]
 
 type ReturnType<F extends SchemaOrFn> = F extends SchemaOrFn<infer S>
@@ -179,6 +180,8 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
     [store, mappedPaths]
   )
 
+  const get = useMemo(() => store.get, [store])
+
   useEffect(() => {
     // We initialize the store with the initialData in useEffect.
     // Note that doing this while rendering (ie in useMemo) would make
@@ -225,6 +228,6 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
     return () => unsubscriptions.forEach((unsub) => unsub())
   }, [onEditStartPaths, onEditEndPaths, store])
 
-  if (schemaIsFunction) return [values, set] as any
+  if (schemaIsFunction) return [values, set, get] as any
   return values as any
 }

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -182,12 +182,7 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
     [store, mappedPaths]
   )
 
-  const get = useCallback(
-    (path: string) => {
-      store.get(mappedPaths[path].path)
-    },
-    [store, mappedPaths]
-  )
+  const get = useCallback((path: string) => store.get(mappedPaths[path].path), [store, mappedPaths])
 
   useEffect(() => {
     // We initialize the store with the initialData in useEffect.

--- a/packages/leva/stories/controlled-inputs.stories.tsx
+++ b/packages/leva/stories/controlled-inputs.stories.tsx
@@ -1,7 +1,6 @@
-import React, { ChangeEventHandler, useCallback } from 'react'
-import { ComponentPropsWithoutRef, forwardRef, useRef } from 'react'
-import { useDrag } from '@use-gesture/react'
 import { Meta, Story } from '@storybook/react'
+import { useDrag } from '@use-gesture/react'
+import React, { ComponentPropsWithoutRef, forwardRef, useCallback, useRef } from 'react'
 import Reset from './components/decorator-reset'
 
 import { useControls } from '../src'

--- a/packages/leva/stories/controlled-inputs.stories.tsx
+++ b/packages/leva/stories/controlled-inputs.stories.tsx
@@ -32,9 +32,14 @@ export const ExternalUpdatesWithSet: Story = () => {
 
 export const ExternalUpdatesWithGetAndSet: Story = () => {
   const [{ counter }, set, get] = useControls(() => ({ counter: { value: 0, step: 1 } }))
+  const [{ counter: counter2 }, set2, get2] = useControls('folder', () => ({ counter: { value: 0, step: 1 } }))
 
   const onClick = useCallback(() => {
     set({ counter: get('counter') + 1 })
+  }, [])
+
+  const onClick2 = useCallback(() => {
+    set2({ counter: get2('folder.counter') + 1 })
   }, [])
 
   return (
@@ -42,6 +47,12 @@ export const ExternalUpdatesWithGetAndSet: Story = () => {
       <label>
         counter: {counter}{' '}
         <button type="button" onClick={onClick}>
+          ➕ inc
+        </button>
+      </label>
+      <label>
+        folder.counter: {counter2}{' '}
+        <button type="button" onClick={onClick2}>
           ➕ inc
         </button>
       </label>

--- a/packages/leva/stories/controlled-inputs.stories.tsx
+++ b/packages/leva/stories/controlled-inputs.stories.tsx
@@ -48,7 +48,7 @@ export const ExternalUpdatesWithGetAndSet: Story = () => {
   }, [])
 
   const onClick3 = useCallback(() => {
-    set2({ counter: get2('counterB') + 1 })
+    set2({ counterB: get2('counterB') + 1 })
   }, [])
 
   return (
@@ -67,7 +67,7 @@ export const ExternalUpdatesWithGetAndSet: Story = () => {
       </label>
       <label>
         folder.folder2.counterB: {counterB}{' '}
-        <button type="button" onClick={onClick2}>
+        <button type="button" onClick={onClick3}>
           ➕ inc
         </button>
       </label>

--- a/packages/leva/stories/controlled-inputs.stories.tsx
+++ b/packages/leva/stories/controlled-inputs.stories.tsx
@@ -32,7 +32,7 @@ export const ExternalUpdatesWithSet: Story = () => {
 }
 
 export const ExternalUpdatesWithGetAndSet: Story = () => {
-  const [{ username, counter }, set, get] = useControls(() => ({ username: 'Mario', counter: { value: 0, step: 1 } }))
+  const [{ counter }, set, get] = useControls(() => ({ counter: { value: 0, step: 1 } }))
 
   const onClick = useCallback(() => {
     set({ counter: get('counter') + 1 })
@@ -40,9 +40,6 @@ export const ExternalUpdatesWithGetAndSet: Story = () => {
 
   return (
     <form style={formStyles}>
-      <label>
-        username: <input type="text" value={username} onChange={(e) => set({ username: e.target.value })} />
-      </label>
       <label>
         counter: {counter}{' '}
         <button type="button" onClick={onClick}>

--- a/packages/leva/stories/controlled-inputs.stories.tsx
+++ b/packages/leva/stories/controlled-inputs.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 import { useDrag } from '@use-gesture/react'
-import React, { ComponentPropsWithoutRef, forwardRef, useCallback, useRef } from 'react'
+import React, { ComponentPropsWithoutRef, forwardRef, useRef } from 'react'
 import Reset from './components/decorator-reset'
 
 import { folder, useControls } from '../src'
@@ -39,17 +39,17 @@ export const ExternalUpdatesWithGetAndSet: Story = () => {
     }),
   }))
 
-  const onClick = useCallback(() => {
+  const onClick = () => {
     set({ counter: get('counter') + 1 })
-  }, [])
+  }
 
-  const onClick2 = useCallback(() => {
+  const onClick2 = () => {
     set2({ counter: get2('counter') + 1 })
-  }, [])
+  }
 
-  const onClick3 = useCallback(() => {
+  const onClick3 = () => {
     set2({ counterB: get2('counterB') + 1 })
-  }, [])
+  }
 
   return (
     <form style={formStyles}>

--- a/packages/leva/stories/controlled-inputs.stories.tsx
+++ b/packages/leva/stories/controlled-inputs.stories.tsx
@@ -3,7 +3,7 @@ import { useDrag } from '@use-gesture/react'
 import React, { ComponentPropsWithoutRef, forwardRef, useCallback, useRef } from 'react'
 import Reset from './components/decorator-reset'
 
-import { useControls } from '../src'
+import { folder, useControls } from '../src'
 
 export default {
   title: 'Misc/Controlled inputs',
@@ -31,15 +31,24 @@ export const ExternalUpdatesWithSet: Story = () => {
 }
 
 export const ExternalUpdatesWithGetAndSet: Story = () => {
-  const [{ counter }, set, get] = useControls(() => ({ counter: { value: 0, step: 1 } }))
-  const [{ counter: counter2 }, set2, get2] = useControls('folder', () => ({ counter: { value: 0, step: 1 } }))
+  const [{ counter }, set, get] = useControls(() => ({ counter: 0 }))
+  const [{ counter: counter2, counterB }, set2, get2] = useControls('folder', () => ({
+    counter: 0,
+    folder2: folder({
+      counterB: 0,
+    }),
+  }))
 
   const onClick = useCallback(() => {
     set({ counter: get('counter') + 1 })
   }, [])
 
   const onClick2 = useCallback(() => {
-    set2({ counter: get2('folder.counter') + 1 })
+    set2({ counter: get2('counter') + 1 })
+  }, [])
+
+  const onClick3 = useCallback(() => {
+    set2({ counter: get2('counterB') + 1 })
   }, [])
 
   return (
@@ -52,6 +61,12 @@ export const ExternalUpdatesWithGetAndSet: Story = () => {
       </label>
       <label>
         folder.counter: {counter2}{' '}
+        <button type="button" onClick={onClick2}>
+          ➕ inc
+        </button>
+      </label>
+      <label>
+        folder.folder2.counterB: {counterB}{' '}
         <button type="button" onClick={onClick2}>
           ➕ inc
         </button>

--- a/packages/leva/stories/controlled-inputs.stories.tsx
+++ b/packages/leva/stories/controlled-inputs.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ChangeEventHandler, useCallback } from 'react'
 import { ComponentPropsWithoutRef, forwardRef, useRef } from 'react'
 import { useDrag } from '@use-gesture/react'
 import { Meta, Story } from '@storybook/react'
@@ -24,6 +24,28 @@ export const ExternalUpdatesWithSet: Story = () => {
       <label>
         counter: {counter}{' '}
         <button type="button" onClick={() => set({ counter: counter + 1 })}>
+          ➕ inc
+        </button>
+      </label>
+    </form>
+  )
+}
+
+export const ExternalUpdatesWithGetAndSet: Story = () => {
+  const [{ username, counter }, set, get] = useControls(() => ({ username: 'Mario', counter: { value: 0, step: 1 } }))
+
+  const onClick = useCallback(() => {
+    set({ counter: get('counter') + 1 })
+  }, [])
+
+  return (
+    <form style={formStyles}>
+      <label>
+        username: <input type="text" value={username} onChange={(e) => set({ username: e.target.value })} />
+      </label>
+      <label>
+        counter: {counter}{' '}
+        <button type="button" onClick={onClick}>
           ➕ inc
         </button>
       </label>


### PR DESCRIPTION
Should support #222 feature request.

Changes:

- `useControls` returns a getter as a third parameter. 
- `useControls` Typescript setter now checks the type of what are you trying to set. 

Example:

```
const [{ counter }, set, get] = useControls(() => ({ counter: 0} }))
const onClick = useCallback(() => {
   set({ counter: get('counter') + 1 })
}, [])
```

[Demo link](https://leva-git-fork-rodrigohamuy-feat-getter-pmndrs.vercel.app/?path=/story/misc-controlled-inputs--external-updates-with-get-and-set)