### PR TITLE
feat: Set inputs and folders order

### DIFF
--- a/.changeset/lucky-actors-share.md
+++ b/.changeset/lucky-actors-share.md
@@ -1,0 +1,5 @@
+---
+'leva': minor
+---
+
+option to set order of inputs and folders

--- a/.changeset/lucky-actors-share.md
+++ b/.changeset/lucky-actors-share.md
@@ -1,5 +1,5 @@
 ---
-'leva': minor
+'leva': patch
 ---
 
 option to set order of inputs and folders

--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -14,26 +14,30 @@ function frame() {
 }
 
 const ExtraControls = () => {
-  const data = useControls('folder.subfolder', {
-    // eslint-disable-next-line no-console
-    'Hello Button': button((get) => console.log('hello', get('folder.subfolder.deep nested.pos2d'))),
-    'deep nested': folder(
-      {
-        pos2d: { value: { x: 3, y: 4 }, lock: true },
-        pos2dArr: [100, 200],
-        pos3d: {
-          value: {
-            x: 0.3,
-            y: 0.1,
-            z: 0.5,
+  const data = useControls(
+    'folder.subfolder',
+    {
+      // eslint-disable-next-line no-console
+      'Hello Button': button((get) => console.log('hello', get('folder.subfolder.deep nested.pos2d'))),
+      'deep nested': folder(
+        {
+          pos2d: { value: { x: 3, y: 4 }, lock: true },
+          pos2dArr: [100, 200],
+          pos3d: {
+            value: {
+              x: 0.3,
+              y: 0.1,
+              z: 0.5,
+            },
+            label: <DimensionsIcon />,
           },
-          label: <DimensionsIcon />,
+          pos3dArr: [Math.PI / 2, 20, 4],
         },
-        pos3dArr: [Math.PI / 2, 20, 4],
-      },
-      { color: 'red' }
-    ),
-  })
+        { color: 'red' }
+      ),
+    },
+    { order: -1 }
+  )
   return <pre>{JSON.stringify(data, null, '  ')}</pre>
 }
 

--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -40,8 +40,8 @@ const ExtraControls = () => {
 function Controls() {
   const data = useControls({
     dimension: '4px',
-    string: { value: 'something', optional: true, order: -1 },
-    range: { value: 0, min: -10, max: 10, order: -2 },
+    string: { value: 'something', optional: true, order: -2 },
+    range: { value: 0, min: -10, max: 10, order: -3 },
     image: { image: undefined },
     select: { options: ['x', 'y', ['x', 'y']] },
     interval: { min: -100, max: 100, value: [-10, 10] },

--- a/demo/src/sandboxes/leva-busy/src/App.tsx
+++ b/demo/src/sandboxes/leva-busy/src/App.tsx
@@ -39,9 +39,9 @@ const ExtraControls = () => {
 
 function Controls() {
   const data = useControls({
-    range: { value: 0, min: -10, max: 10 },
     dimension: '4px',
-    string: 'something',
+    string: { value: 'something', optional: true, order: -1 },
+    range: { value: 0, min: -10, max: 10, order: -2 },
     image: { image: undefined },
     select: { options: ['x', 'y', ['x', 'y']] },
     interval: { min: -100, max: 100, value: [-10, 10] },
@@ -60,7 +60,7 @@ function Controls() {
         boolean: true,
         spring: { tension: 100, friction: 30 },
       },
-      { color: 'yellow' }
+      { color: 'yellow', order: -1 }
     ),
   })
   return <pre>{JSON.stringify(data, null, '  ')}</pre>

--- a/demo/src/sandboxes/leva-ui/src/App.jsx
+++ b/demo/src/sandboxes/leva-ui/src/App.jsx
@@ -72,6 +72,7 @@ function Box({ index, selected, setSelect }) {
     maxFiles: 1,
     accept: 'image/*',
     onDrop,
+    noClick: true,
   })
 
   const background = fillMode === 'color' || !fillImage ? fillColor : `center / cover no-repeat url(${fillImage})`

--- a/packages/leva/src/components/Folder/Folder.tsx
+++ b/packages/leva/src/components/Folder/Folder.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useRef, useLayoutEffect } from 'react'
-import { FolderTitle } from './FolderTitle'
-import { StyledFolder, StyledWrapper, StyledContent } from './StyledFolder'
-import { isInput } from '../Leva/tree'
+import React, { useLayoutEffect, useRef, useState } from 'react'
+import { useStoreContext } from '../../context'
+import { useToggle } from '../../hooks'
+import { useTh } from '../../styles'
+import type { StoreType, Tree } from '../../types'
 import { join } from '../../utils'
 import { Control } from '../Control'
-import { useToggle } from '../../hooks'
-import { useStoreContext } from '../../context'
-import type { Tree } from '../../types'
-import { useTh } from '../../styles'
+import { isInput } from '../Leva/tree'
+import { FolderTitle } from './FolderTitle'
+import { StyledContent, StyledFolder, StyledWrapper } from './StyledFolder'
 
 type FolderProps = { name: string; path?: string; tree: Tree }
 
@@ -47,10 +47,12 @@ type TreeWrapperProps = {
 export const TreeWrapper = React.memo(
   ({ isRoot = false, fill = false, flat = false, parent, tree, toggled }: TreeWrapperProps) => {
     const { wrapperRef, contentRef } = useToggle(toggled)
+    const store = useStoreContext()
+    const entries = Object.entries(tree).sort((a, b) => getOrder(a[0], store) - getOrder(b[0], store))
     return (
       <StyledWrapper ref={wrapperRef} isRoot={isRoot} fill={fill} flat={flat}>
         <StyledContent ref={contentRef} isRoot={isRoot} toggled={toggled}>
-          {Object.entries(tree).map(([key, value]) =>
+          {entries.map(([key, value]) =>
             isInput(value) ? (
               // @ts-expect-error
               <Control key={value.path} valueKey={value.valueKey} path={value.path} />
@@ -63,3 +65,12 @@ export const TreeWrapper = React.memo(
     )
   }
 )
+
+function getOrder(path: string, store: StoreType) {
+  const order =
+    {
+      ...store.getFolderSettings(path),
+      ...store.getInput(path)?.settings,
+    }?.order || 0
+  return order
+}

--- a/packages/leva/src/components/Folder/Folder.tsx
+++ b/packages/leva/src/components/Folder/Folder.tsx
@@ -2,7 +2,7 @@ import React, { useLayoutEffect, useRef, useState } from 'react'
 import { useStoreContext } from '../../context'
 import { useToggle } from '../../hooks'
 import { useTh } from '../../styles'
-import type { StoreType, Tree } from '../../types'
+import type { Tree } from '../../types'
 import { join } from '../../utils'
 import { Control } from '../Control'
 import { isInput } from '../Leva/tree'
@@ -48,7 +48,13 @@ export const TreeWrapper = React.memo(
   ({ isRoot = false, fill = false, flat = false, parent, tree, toggled }: TreeWrapperProps) => {
     const { wrapperRef, contentRef } = useToggle(toggled)
     const store = useStoreContext()
-    const entries = Object.entries(tree).sort((a, b) => getOrder(a[0], store) - getOrder(b[0], store))
+
+    const getOrder = ([key, o]: [key: string, o: any]) => {
+      const order = isInput(o) ? store.getInput(o.path)?.order : store.getFolderSettings(join(parent, key)).order
+      return order || 0
+    }
+
+    const entries = Object.entries(tree).sort((a, b) => getOrder(a) - getOrder(b))
     return (
       <StyledWrapper ref={wrapperRef} isRoot={isRoot} fill={fill} flat={flat}>
         <StyledContent ref={contentRef} isRoot={isRoot} toggled={toggled}>
@@ -65,12 +71,3 @@ export const TreeWrapper = React.memo(
     )
   }
 )
-
-function getOrder(path: string, store: StoreType) {
-  const order =
-    {
-      ...store.getFolderSettings(path),
-      ...store.getInput(path)?.settings,
-    }?.order || 0
-  return order
-}

--- a/packages/leva/src/components/String/string-plugin.ts
+++ b/packages/leva/src/components/String/string-plugin.ts
@@ -8,9 +8,9 @@ export const sanitize = (v: any) => {
   return v
 }
 
-export const normalize = ({ value, editable = true, rows = false }: StringInput) => {
+export const normalize = ({ value, editable = true, rows = false, ...props }: StringInput) => {
   return {
     value,
-    settings: { editable, rows: typeof rows === 'number' ? rows : rows ? 5 : 0 },
+    settings: { editable, rows: typeof rows === 'number' ? rows : rows ? 5 : 0, ...props },
   }
 }

--- a/packages/leva/src/components/String/string-plugin.ts
+++ b/packages/leva/src/components/String/string-plugin.ts
@@ -8,9 +8,9 @@ export const sanitize = (v: any) => {
   return v
 }
 
-export const normalize = ({ value, editable = true, rows = false, ...props }: StringInput) => {
+export const normalize = ({ value, editable = true, rows = false }: StringInput) => {
   return {
     value,
-    settings: { editable, rows: typeof rows === 'number' ? rows : rows ? 5 : 0, ...props },
+    settings: { editable, rows: typeof rows === 'number' ? rows : rows ? 5 : 0 },
   }
 }

--- a/packages/leva/src/store.ts
+++ b/packages/leva/src/store.ts
@@ -66,9 +66,10 @@ export const Store = function (this: StoreType) {
         hiddenFolders.every((p) => path.indexOf(p) === -1) &&
         // if its render functions doesn't exists or returns true
         (!data[path].render || data[path].render!(this.get))
-      )
+      ) {
         // then the input path is visible
         visiblePaths.push(path)
+      }
     })
 
     return visiblePaths

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -64,6 +64,8 @@ export type DataInput = {
   __refCount: number
   type: string
   value: unknown
+  /** works similar to css order property */
+  order?: number
   /**
    * Whether the onChange handler invocation is caused internally via the panel or  externally via a set call.
    */

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -47,6 +47,7 @@ export type CommonOptions = {
   label: string | JSX.Element
   hint?: string
   render?: RenderFn
+  order: number
 }
 
 export type DataInputOptions = CommonOptions & {
@@ -64,8 +65,6 @@ export type DataInput = {
   __refCount: number
   type: string
   value: unknown
-  /** works similar to css order property */
-  order?: number
   /**
    * Whether the onChange handler invocation is caused internally via the panel or  externally via a set call.
    */

--- a/packages/leva/src/types/public.ts
+++ b/packages/leva/src/types/public.ts
@@ -78,7 +78,13 @@ export type MonitorInput = {
 
 export type SpecialInput = MonitorInput | ButtonInput | ButtonGroupInput
 
-export type FolderSettings = { collapsed?: boolean; render?: RenderFn; color?: string }
+export type FolderSettings = {
+  collapsed?: boolean
+  render?: RenderFn
+  color?: string
+  /** works similar to css order property */
+  order?: number
+}
 
 export type NumberSettings = { min?: number; max?: number; step?: number }
 

--- a/packages/leva/src/types/public.ts
+++ b/packages/leva/src/types/public.ts
@@ -145,6 +145,7 @@ type GenericSchemaItemOptions = {
   render?: RenderFn
   label?: string | JSX.Element
   hint?: string
+  order?: number
 }
 
 type OnHandlerContext = DataInput & { get(path: string): any }

--- a/packages/leva/src/utils/input.ts
+++ b/packages/leva/src/utils/input.ts
@@ -34,6 +34,7 @@ export function parseOptions(
         label: key,
         optional: false,
         disabled: false,
+        order: 0,
         ...mergedOptions,
       },
     }
@@ -53,8 +54,19 @@ export function parseOptions(
   }
 
   // parse generic options from input object
-  const { render, label, optional, disabled, hint, onChange, onEditStart, onEditEnd, transient, ...inputWithType } =
-    _input
+  const {
+    render,
+    label,
+    optional,
+    order = 0,
+    disabled,
+    hint,
+    onChange,
+    onEditStart,
+    onEditEnd,
+    transient,
+    ...inputWithType
+  } = _input
 
   const commonOptions = {
     render,
@@ -66,6 +78,7 @@ export function parseOptions(
     onEditEnd,
     disabled,
     optional,
+    order,
     ...mergedOptions,
   }
 

--- a/packages/leva/src/utils/input.ts
+++ b/packages/leva/src/utils/input.ts
@@ -182,11 +182,20 @@ export function sanitizeValue({ type, value, settings }: SanitizeProps, newValue
      * the value to be notified (ie there wouldn't be a new render)
      */
 
+    /**
+     * @update 22.10.22 this warning is a bit cumbersome when dragging something, which can
+     * result in the same value being set. Commenting out.
+     */
+
+    return value
+
+    /*
     throw new ValueError(
       `The value \`${newValue}\` did not result in a value update, which remained the same: \`${value}\`.
         You can ignore this warning if this is the intended behavior.`,
       value
     )
+    */
   }
   return sanitizedNewValue
 }

--- a/packages/leva/stories/Folder.stories.tsx
+++ b/packages/leva/stories/Folder.stories.tsx
@@ -96,3 +96,17 @@ export const NestedFolders = () => {
     </div>
   )
 }
+
+export const OrderedFolders = () => {
+  const values = useControls(() => ({
+    last: folder({ firstVal: 0 }, { order: 1, collapsed: true }),
+    middle: folder({ secondVal: 0 }, { order: -1, collapsed: true }),
+    first: { value: 0, order: -2 },
+  }))
+
+  return (
+    <div>
+      <pre>{JSON.stringify(values, null, '  ')}</pre>
+    </div>
+  )
+}

--- a/packages/leva/stories/input-options.stories.tsx
+++ b/packages/leva/stories/input-options.stories.tsx
@@ -254,3 +254,19 @@ export const OnEditStartOnEditEndMultiPanel = () => {
 }
 
 OnEditStartOnEditEndMultiPanel.storyName = 'onEdit Multiple Callbacks'
+
+export const Ordered = () => {
+  const values = useControls(() => ({
+    last: folder({ firstVal: 0 }, { order: 1, collapsed: true }),
+    middle: folder({ secondVal: 0 }, { order: -1, collapsed: true }),
+    first: { value: 0, order: -2 },
+  }))
+
+  return (
+    <div>
+      <pre>{JSON.stringify(values, null, '  ')}</pre>
+    </div>
+  )
+}
+
+Ordered.storyName = 'ordered folders and inputs'

--- a/packages/leva/stories/input-options.stories.tsx
+++ b/packages/leva/stories/input-options.stories.tsx
@@ -259,7 +259,7 @@ export const Ordered = () => {
   const values = useControls(() => ({
     last: folder({ firstVal: 0 }, { order: 1, collapsed: true }),
     middle: folder({ secondVal: 0 }, { order: -1, collapsed: true }),
-    first: { value: 0, order: -2 },
+    first: { value: 'ola', order: -2 },
   }))
 
   return (


### PR DESCRIPTION
Allow to set the order in which elements appear, following a rule similar to CSS order property.

Example:

```
useControls(() => ({
  last: folder({ firstVal: 0 }, { order: 1, collapsed: true }),
  middle: folder({ secondVal: 0 }, { order: -1, collapsed: true }),
  first: { value: 0, order: -2 },
}))
```