### PR TITLE
fix: respect typescript null reference

### DIFF
--- a/.changeset/fuzzy-drinks-invite.md
+++ b/.changeset/fuzzy-drinks-invite.md
@@ -1,0 +1,5 @@
+---
+'leva': patch
+---
+
+fix: respect ts null reference

--- a/packages/leva/src/components/Folder/Folder.tsx
+++ b/packages/leva/src/components/Folder/Folder.tsx
@@ -23,8 +23,9 @@ const Folder = ({ name, path, tree }: FolderProps) => {
   const textColor = useTh('colors', 'folderTextColor')
 
   useLayoutEffect(() => {
-    folderRef.current!.style.setProperty('--leva-colors-folderWidgetColor', color || widgetColor)
-    folderRef.current!.style.setProperty('--leva-colors-folderTextColor', color || textColor)
+    if (!folderRef.current) return
+    folderRef.current.style.setProperty('--leva-colors-folderWidgetColor', color || widgetColor)
+    folderRef.current.style.setProperty('--leva-colors-folderTextColor', color || textColor)
   }, [color, widgetColor, textColor])
 
   return (

--- a/packages/leva/src/components/Interval/Interval.tsx
+++ b/packages/leva/src/components/Interval/Interval.tsx
@@ -22,8 +22,9 @@ function IntervalSlider({ value, bounds: [min, max], onDrag, ...settings }: Inte
   const scrubberWidth = useTh('sizes', 'scrubberWidth')
 
   const bind = useDrag(({ event, first, xy: [x], movement: [mx], memo = {} }) => {
+    if (!ref.current) return
     if (first) {
-      const { width, left } = ref.current!.getBoundingClientRect()
+      const { width, left } = ref.current.getBoundingClientRect()
       rangeWidth.current = width - parseFloat(scrubberWidth)
 
       const targetIsScrub = event?.target === minScrubberRef.current || event?.target === maxScrubberRef.current

--- a/packages/leva/src/components/Number/RangeSlider.tsx
+++ b/packages/leva/src/components/Number/RangeSlider.tsx
@@ -13,9 +13,10 @@ export function RangeSlider({ value, min, max, onDrag, step, initialValue }: Ran
   const scrubberWidth = useTh('sizes', 'scrubberWidth')
 
   const bind = useDrag(({ event, first, xy: [x], movement: [mx], memo }) => {
+    if (!ref.current) return memo
     if (first) {
       // rangeWidth is the width of the slider el minus the width of the scrubber el itself
-      const { width, left } = ref.current!.getBoundingClientRect()
+      const { width, left } = ref.current.getBoundingClientRect()
       rangeWidth.current = width - parseFloat(scrubberWidth)
 
       const targetIsScrub = event?.target === scrubberRef.current

--- a/packages/leva/src/components/Vector2d/Joystick.tsx
+++ b/packages/leva/src/components/Vector2d/Joystick.tsx
@@ -25,10 +25,11 @@ export function Joystick({ value, settings, onUpdate }: JoystickProps) {
   const playgroundRef = useRef<HTMLDivElement>(null)
 
   useLayoutEffect(() => {
+    if (!joystickeRef.current || !playgroundRef.current) return
     if (joystickShown) {
-      const { top, left, width, height } = joystickeRef.current!.getBoundingClientRect()
-      playgroundRef.current!.style.left = left + width / 2 + 'px'
-      playgroundRef.current!.style.top = top + height / 2 + 'px'
+      const { top, left, width, height } = joystickeRef.current.getBoundingClientRect()
+      playgroundRef.current.style.left = left + width / 2 + 'px'
+      playgroundRef.current.style.top = top + height / 2 + 'px'
     }
   }, [joystickShown])
 

--- a/packages/leva/src/hooks/useCanvas.ts
+++ b/packages/leva/src/hooks/useCanvas.ts
@@ -12,8 +12,9 @@ export function useCanvas2d(
   // have a fixed width
   useEffect(() => {
     const handleCanvas = debounce(() => {
-      canvas.current!.width = canvas.current!.offsetWidth * window.devicePixelRatio
-      canvas.current!.height = canvas.current!.offsetHeight * window.devicePixelRatio
+      if (!canvas.current) return
+      canvas.current.width = canvas.current.offsetWidth * window.devicePixelRatio
+      canvas.current.height = canvas.current.offsetHeight * window.devicePixelRatio
       fn(canvas.current, ctx.current)
     }, 250)
     window.addEventListener('resize', handleCanvas)
@@ -25,7 +26,8 @@ export function useCanvas2d(
   }, [fn])
 
   useEffect(() => {
-    ctx.current = canvas.current!.getContext('2d')
+    if (!canvas.current) return
+    ctx.current = canvas.current.getContext('2d')
   }, [])
 
   return [canvas, ctx]

--- a/packages/leva/src/hooks/usePopin.ts
+++ b/packages/leva/src/hooks/usePopin.ts
@@ -10,17 +10,18 @@ export function usePopin(margin = 3) {
   const hide = useCallback(() => setShow(false), [])
 
   useLayoutEffect(() => {
+    if (!popinRef.current || !wrapperRef.current) return
     if (shown) {
-      const { bottom, top, left } = popinRef.current!.getBoundingClientRect()
-      const { height } = wrapperRef.current!.getBoundingClientRect()
+      const { bottom, top, left } = popinRef.current.getBoundingClientRect()
+      const { height } = wrapperRef.current.getBoundingClientRect()
       const direction = bottom + height > window.innerHeight - 40 ? 'up' : 'down'
 
-      wrapperRef.current!.style.position = 'fixed'
-      wrapperRef.current!.style.zIndex = '10000'
-      wrapperRef.current!.style.left = left + 'px'
+      wrapperRef.current.style.position = 'fixed'
+      wrapperRef.current.style.zIndex = '10000'
+      wrapperRef.current.style.left = left + 'px'
 
-      if (direction === 'down') wrapperRef.current!.style.top = bottom + margin + 'px'
-      else wrapperRef.current!.style.bottom = window.innerHeight - top + margin + 'px'
+      if (direction === 'down') wrapperRef.current.style.top = bottom + margin + 'px'
+      else wrapperRef.current.style.bottom = window.innerHeight - top + margin + 'px'
     }
   }, [margin, shown])
 

--- a/packages/leva/src/hooks/useToggle.ts
+++ b/packages/leva/src/hooks/useToggle.ts
@@ -8,9 +8,10 @@ export function useToggle(toggled: boolean) {
   // this should be fine for SSR since the store is set in useEffect and
   // therefore the pane doesn't show on first render.
   useLayoutEffect(() => {
+    if (!wrapperRef.current) return
     if (!toggled) {
-      wrapperRef.current!.style.height = '0px'
-      wrapperRef.current!.style.overflow = 'hidden'
+      wrapperRef.current.style.height = '0px'
+      wrapperRef.current.style.overflow = 'hidden'
     }
     // we only want to do this once so that's ok to break the rules of hooks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -23,20 +24,23 @@ export function useToggle(toggled: boolean) {
       return
     }
 
+    if (!contentRef.current) return
+
     let timeout: number
     const ref = wrapperRef.current!
 
     const fixHeight = () => {
+      if (!contentRef.current) return
       if (toggled) {
         ref.style.removeProperty('height')
         ref.style.removeProperty('overflow')
-        contentRef.current!.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        contentRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
       }
     }
 
     ref.addEventListener('transitionend', fixHeight, { once: true })
 
-    const { height } = contentRef.current!.getBoundingClientRect()
+    const { height } = contentRef.current.getBoundingClientRect()
     ref.style.height = height + 'px'
     if (!toggled) {
       ref.style.overflow = 'hidden'

--- a/packages/leva/stories/controlled-inputs.stories.tsx
+++ b/packages/leva/stories/controlled-inputs.stories.tsx
@@ -112,8 +112,9 @@ export const OnChangeAndSet: Story = () => {
 
   useDrag(
     ({ first, last, offset: [x, y] }) => {
-      if (first) circleRef.current!.style.cursor = 'grabbing'
-      if (last) circleRef.current!.style.removeProperty('cursor')
+      if (!circleRef.current) return
+      if (first) circleRef.current.style.cursor = 'grabbing'
+      if (last) circleRef.current.style.removeProperty('cursor')
       set({ position: { x, y } })
     },
     { target: circleRef }

--- a/packages/plugin-bezier/src/BezierSvg.tsx
+++ b/packages/plugin-bezier/src/BezierSvg.tsx
@@ -36,15 +36,16 @@ export function BezierSvg({
   const bounds = useRef<DOMRect>()
 
   const bind = useDrag(({ xy: [x, y], event, first, memo }) => {
+    if (!bounds.current || !svgRef.current) return memo
     if (first) {
-      bounds.current = svgRef.current!.getBoundingClientRect()
-      memo = [handleLeft.current, handleRight.current].indexOf(event!.target as any)
+      bounds.current = svgRef.current.getBoundingClientRect()
+      memo = [handleLeft.current, handleRight.current].indexOf(event.target as any)
       if (memo < 0) memo = x - bounds.current.left < width / 2 ? 0 : 1
       memo *= 2
     }
 
-    const relX = x - bounds.current!.left
-    const relY = y - bounds.current!.top
+    const relX = x - bounds.current.left
+    const relY = y - bounds.current.top
 
     onUpdate((v: BezierType) => {
       const newV = [...v]

--- a/packages/plugin-plot/src/PlotCanvas.tsx
+++ b/packages/plugin-plot/src/PlotCanvas.tsx
@@ -76,8 +76,9 @@ export const PlotCanvas = React.memo(({ value: expr, settings }: PlotCanvasProps
   const canvasBounds = useRef<DOMRect>()
 
   const bind = useMove(({ xy: [x], first }) => {
+    if (!canvas.current) return
     if (first) {
-      canvasBounds.current = canvas.current!.getBoundingClientRect()
+      canvasBounds.current = canvas.current.getBoundingClientRect()
     }
     const { left, top, width, height } = canvasBounds.current!
     const [minX, maxX] = boundsX


### PR DESCRIPTION
This fix is just to avoid using `ref.current!.something` and instead check if it is defined or not beforehand.

The reason behind this is that if you are using a test library that does not support DOM, Leva will force a fail as it expect DOM references to never be null.