### PR TITLE
fix: scrolling long panels

### DIFF
--- a/.changeset/grumpy-horses-wash.md
+++ b/.changeset/grumpy-horses-wash.md
@@ -1,0 +1,6 @@
+---
+'leva': patch
+'@leva-ui/plugin-dates': patch
+---
+
+fix: scrolling long panels

--- a/packages/leva/src/components/Folder/StyledFolder.ts
+++ b/packages/leva/src/components/Folder/StyledFolder.ts
@@ -33,7 +33,7 @@ export const StyledWrapper = styled('div', {
       fill: false,
       css: {
         // TODO: fix for calendar popup
-        // overflowY: 'auto',
+        overflowY: 'auto',
         // 20px accounts for top margin
         maxHeight: 'calc(100vh - 20px - $$titleBarHeight)',
       },

--- a/packages/leva/stories/panel-options.stories.tsx
+++ b/packages/leva/stories/panel-options.stories.tsx
@@ -100,3 +100,14 @@ export const NeverHide: Story<any> = () => {
     </div>
   )
 }
+
+export const ReallyLongPanel = () => {
+  useControls({
+    ...Object.fromEntries(
+      Array(50)
+        .fill(0)
+        .map((_, i) => [i, i])
+    ),
+  })
+  return <></>
+}

--- a/packages/plugin-dates/src/Date.stories.tsx
+++ b/packages/plugin-dates/src/Date.stories.tsx
@@ -25,3 +25,18 @@ CustomLocale.args = { date: new Date(), locale: 'en-US' }
 
 export const CustomInputFormat = Template.bind({})
 CustomInputFormat.args = { date: new Date(), inputFormat: 'yyyy-MM-dd' }
+
+export const WithOtherFields = () => {
+  const { birthday, ...values } = useControls({
+    text: 'text',
+    birthday: date({ date: new Date() }),
+    number: 0,
+  })
+  return (
+    <div>
+      {birthday.formattedDate}
+      <br />
+      {JSON.stringify(values)}
+    </div>
+  )
+}

--- a/packages/plugin-dates/src/Date.tsx
+++ b/packages/plugin-dates/src/Date.tsx
@@ -1,5 +1,5 @@
 import { Components, useInputContext } from 'leva/plugin'
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useState } from 'react'
 import DatePicker, { CalendarContainer } from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import { DateCalendarContainerProps, DateInputProps, DateProps } from './date-types'
@@ -22,8 +22,10 @@ const DateInput = forwardRef<HTMLInputElement, Partial<DateInputProps>>(({ value
 export function Date() {
   const { label, value, onUpdate, settings } = useInputContext<DateProps>()
 
+  const [isOpen, setIsOpen] = useState(false)
+
   return (
-    <Row input>
+    <Row input style={{ height: isOpen ? 300 : 'auto' }}>
       <Label>{label}</Label>
       <InputContainer>
         <DatePicker
@@ -32,6 +34,8 @@ export function Date() {
           dateFormat={settings.inputFormat}
           calendarContainer={DateCalendarContainer}
           customInput={<DateInput />}
+          onCalendarOpen={() => setIsOpen(true)}
+          onCalendarClose={() => setIsOpen(false)}
         />
       </InputContainer>
     </Row>


### PR DESCRIPTION
To support the date plugin, a CSS change was made that broke scrolling on long panels.

This PR fixes that, by reverting that line of CSS and instead changing the date panel's height depending on wherever the pop-up is open or close. Maybe is not the nicest solution, so open to suggestions!

You can test the fix in the following storybook stories:
- Dates > With Other Fields
- Panel options > Really Long Panel