### PR TITLE
Add explicit files list to package.json

### DIFF
--- a/docs/advanced/controlled-inputs.md
+++ b/docs/advanced/controlled-inputs.md
@@ -16,7 +16,7 @@ See an [example in Storybook](https://leva.pmnd.rs/?path=/story/misc-controlled-
 
 ## onChange
 
-`onChange` callback in the schema is called for all changes to the value. Values with `onChange` will no longer cause React to rerender (unless passing an additional `transient` flag set to `true`, see below), so you can use it to efficiently update frequently changing values.
+`onChange` callback in the schema is called for all changes to the value. Values with `onChange` will no longer cause React to rerender (unless passing an additional `transient` flag set to `false`, see below), so you can use it to efficiently update frequently changing values.
 
 ```jsx
 const divRef = React.useRef(null)

--- a/docs/advanced/controlled-inputs.md
+++ b/docs/advanced/controlled-inputs.md
@@ -16,7 +16,7 @@ See an [example in Storybook](https://leva.pmnd.rs/?path=/story/misc-controlled-
 
 ## onChange
 
-`onChange` callback in the schema is called for all changes to the value. Values with `onChange` will no longer cause React to rerender (unless passing an additional `transient` flag set to `false`, see below), so you can use it to efficiently update frequently changing values.
+`onChange` callback in the schema is called for all changes to the value. Values with `onChange` will no longer cause React to rerender (unless passing an additional `transient` flag set to `true`, see below), so you can use it to efficiently update frequently changing values.
 
 ```jsx
 const divRef = React.useRef(null)

--- a/packages/leva/package.json
+++ b/packages/leva/package.json
@@ -17,6 +17,12 @@
       "plugin/index.ts"
     ]
   },
+  "files": [
+    "*.md",
+    "dist",
+    "src",
+    "plugins"
+  ],
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"


### PR DESCRIPTION
I noticed during development on https://github.com/mentat-collective/leva.cljs that the NPM package for leva is accidentally shipping with a `node_modules` folder:

https://unpkg.com/browse/leva@0.9.34/

It also includes the `plugin` and `stories` directories, which seems like it may not have been intentional.

This PR adds a `"files"` entry to package.json, so that entries in the npm package become opt-in.

I expect you'll have feedback on exactly what we DO want to include. Thank you for the library, hope this is helpful!