### PR TITLE
export function backing "evaluate" property

### DIFF
--- a/packages/plugin-bezier/src/index.ts
+++ b/packages/plugin-bezier/src/index.ts
@@ -2,6 +2,7 @@ import { createPlugin, formatVector } from 'leva/plugin'
 import { Bezier } from './Bezier'
 import { normalize, sanitize } from './bezier-plugin'
 import { InternalBezierSettings } from './bezier-types'
+import { bezier as evaluateBezier } from './bezier-utils'
 
 export const bezier = createPlugin({
   normalize,
@@ -9,3 +10,5 @@ export const bezier = createPlugin({
   format: (value: any, settings: InternalBezierSettings) => formatVector(value, settings),
   component: Bezier,
 })
+
+export { evaluateBezier }


### PR DESCRIPTION
Here were my Discord notes backing this request:

"I have an example going with the Bezier plugin, and noticed that the returned value is an array of four entries, BUT ALSO used as an object, with a couple of keys added for (I think) evaluate etc.

This is convenient... but these keys don't survive conversion to ClojureScript, and the code isn't structured to make it easy to recover those values with only the 4 bezier curve entries.

What do you think of restructuring the code to export an  evaluate function that takes the array of 4 entries as well as a point? we can keep the current behavior, but the change would let me evaluate without the plugin internally building that evaluate function for me."