### PR TITLE
feat: use Pointer Lock API for Number input

### DIFF
--- a/.changeset/clever-experts-perform.md
+++ b/.changeset/clever-experts-perform.md
@@ -1,0 +1,5 @@
+---
+'leva': minor
+---
+
+feat: use Pointer Lock API for Number input

--- a/packages/leva/package.json
+++ b/packages/leva/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leva",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "main": "dist/leva.cjs.js",
   "module": "dist/leva.esm.js",
   "types": "dist/leva.cjs.d.ts",

--- a/packages/leva/package.json
+++ b/packages/leva/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leva",
-  "version": "0.9.36",
+  "version": "0.9.35",
   "main": "dist/leva.cjs.js",
   "module": "dist/leva.esm.js",
   "types": "dist/leva.cjs.d.ts",

--- a/packages/leva/src/components/Number/Number.tsx
+++ b/packages/leva/src/components/Number/Number.tsx
@@ -18,7 +18,13 @@ type DraggableLabelProps = {
 
 const DraggableLabel = React.memo(({ label, onUpdate, step, innerLabelTrim }: DraggableLabelProps) => {
   const [dragging, setDragging] = useState(false)
-  const bind = useDrag(({ active, delta: [dx], event, memo = 0 }) => {
+  const bind = useDrag(({ active, delta: [dx], event, memo = 0, first, last, target }) => {
+    if (first) {
+      ;(target as HTMLElement).requestPointerLock()
+    }
+    if (last) {
+      document.exitPointerLock()
+    }
     setDragging(active)
     memo += dx / 2
     if (Math.abs(memo) >= 1) {

--- a/packages/leva/src/components/Number/Number.tsx
+++ b/packages/leva/src/components/Number/Number.tsx
@@ -20,7 +20,8 @@ const DraggableLabel = React.memo(({ label, onUpdate, step, innerLabelTrim }: Dr
   const [dragging, setDragging] = useState(false)
   const bind = useDrag(({ active, delta: [dx], event, memo = 0, first, last, target }) => {
     if (first) {
-      ;(target as HTMLElement).requestPointerLock()
+      const label = target as HTMLElement
+      label.requestPointerLock()
     }
     if (last) {
       document.exitPointerLock()


### PR DESCRIPTION
Pointer Lock API allows the user to drag the input label outside the boundaries of the browser, while hiding the cursor. This creates a better experience similar to Blender or any other edition tool.

![Kapture 2023-07-03 at 15 13 40](https://github.com/pmndrs/leva/assets/11951424/6829f87e-e5d1-4432-b297-edbf1222c824)

[More information on Pointer Lock API here](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API)