### PR TITLE
feat: add disable cache option

### DIFF
--- a/.changeset/cuddly-zebras-leave.md
+++ b/.changeset/cuddly-zebras-leave.md
@@ -1,0 +1,5 @@
+---
+'leva': minor
+---
+
+Leva cache can be now disabled via `levaStore.disableCache(flag: boolean)` or `<Leva disableCache />` flag.

--- a/packages/leva/src/components/Leva/Leva.tsx
+++ b/packages/leva/src/components/Leva/Leva.tsx
@@ -6,10 +6,10 @@ import { render } from '../../utils/react'
 let rootInitialized = false
 let rootEl: HTMLElement | null = null
 
-type LevaProps = Omit<Partial<LevaRootProps>, 'store'> & { isRoot?: boolean }
+type LevaProps = Omit<Partial<LevaRootProps>, 'store'> & { isRoot?: boolean; disableCache?: boolean }
 
 // uses global store
-export function Leva({ isRoot = false, ...props }: LevaProps) {
+export function Leva({ isRoot = false, disableCache, ...props }: LevaProps) {
   useEffect(() => {
     rootInitialized = true
     // if this panel was attached somewhere in the app and there is already
@@ -22,6 +22,10 @@ export function Leva({ isRoot = false, ...props }: LevaProps) {
       if (!isRoot) rootInitialized = false
     }
   }, [isRoot])
+
+  useEffect(() => {
+    levaStore.disableCache(!!disableCache)
+  }, [disableCache])
 
   return <LevaRoot store={levaStore} {...props} />
 }

--- a/packages/leva/src/store.ts
+++ b/packages/leva/src/store.ts
@@ -93,20 +93,26 @@ export const Store = function (this: StoreType) {
    * @param paths
    */
   this.disposePaths = (paths) => {
+    const disableCache = store.getState().disableCache
     store.setState((s) => {
       const data = s.data
       paths.forEach((path) => {
-        if (path in data) {
-          const input = data[path]
-          input.__refCount--
-          if (input.__refCount === 0 && input.type in SpecialInputs) {
-            // this makes sure special inputs such as buttons are properly
-            // refreshed. This might need some attention though.
-            delete data[path]
-          }
-        }
+        if (!(path in data)) return
+        const input = data[path]
+        input.__refCount--
+        if (input.__refCount !== 0) return
+        // we clear only `SpecialInputs` like buttons
+        // but if the cache is disabled we clear all inputs
+        if (!disableCache && !(input.type in SpecialInputs)) return
+        delete data[path]
       })
       return { data }
+    })
+  }
+
+  this.disableCache = (disableCache) => {
+    store.setState(() => {
+      return { disableCache }
     })
   }
 

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -2,7 +2,7 @@ import type { UseBoundStore } from 'zustand'
 import { StoreApiWithSubscribeWithSelector } from 'zustand/middleware'
 import type { SpecialInput, RenderFn, FolderSettings, Plugin, OnChangeHandler } from './public'
 
-export type State = { data: Data }
+export type State = { data: Data; disableCache?: boolean }
 
 export type MappedPaths = Record<
   string,
@@ -24,6 +24,7 @@ export type StoreType = {
   setOrderedPaths: (newPaths: string[]) => void
   disposePaths: (paths: string[]) => void
   dispose: () => void
+  disableCache: (flag: boolean) => void
   getVisiblePaths: () => string[]
   getFolderSettings: (path: string) => FolderSettings
   getData: () => Data

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -205,11 +205,16 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
       const unsub = store.useStore.subscribe(
         (s) => {
           const input = s.data[path]
+          if (input === undefined) return
           // @ts-ignore
           const value = input.disabled ? undefined : input.value
           return [value, input]
         },
-        ([value, input]: any) => onChange(value, path, { initial: false, get: store.get, ...input }),
+        (props: any) => {
+          if (props === undefined) return
+          const [value, input] = props
+          onChange(value, path, { initial: false, get: store.get, ...input })
+        },
         { equalityFn: shallow }
       )
       unsubscriptions.push(unsub)

--- a/packages/leva/stories/caching.stories.tsx
+++ b/packages/leva/stories/caching.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Reset from './components/decorator-reset'
 import { Story, Meta } from '@storybook/react'
 
-import { useControls } from '../src'
+import { levaStore, useControls } from '../src'
 
 export default {
   title: 'Hook/Caching',
@@ -21,9 +21,14 @@ const Controls = () => {
 
 const Template: Story<any> = () => {
   const [mounted, toggle] = React.useState(true)
+  const [cached, setCached] = React.useState(true)
+  useEffect(() => {
+    levaStore.disableCache(cached)
+  }, [cached])
   return (
     <div>
       <button onClick={() => toggle((t) => !t)}>{mounted ? 'Unmount' : 'Mount'}</button>
+      <button onClick={() => setCached((t) => !t)}>Cache {cached ? 'enabled' : 'disabled'}</button>
       {mounted && <Controls />}
     </div>
   )


### PR DESCRIPTION
Leva cache can be now disabled via `levaStore.disableCache(flag: boolean)` or `<Leva disableCache />` flag.

Added example in the caching story.

**Why**

Some people may prefer controls to be cleared out on unmount for consistency (no after effects) and to avoid memory leaks.