### PR TITLE
Fix: Joystick breaking

### DIFF
--- a/packages/leva/src/components/UI/StyledUI.ts
+++ b/packages/leva/src/components/UI/StyledUI.ts
@@ -4,7 +4,7 @@ import { StyledContent } from '../Folder/StyledFolder'
 
 export const StyledRow = styled('div', {
   position: 'relative',
-  zIndex: 100,
+  zIndex: 'auto',
   display: 'grid',
   rowGap: '$rowGap',
   gridTemplateRows: 'minmax($sizes$rowHeight, max-content)',

--- a/packages/leva/src/components/Vector2d/Joystick.tsx
+++ b/packages/leva/src/components/Vector2d/Joystick.tsx
@@ -3,7 +3,6 @@ import { useDrag } from '../../hooks'
 import { clamp, multiplyStep } from '../../utils'
 import { JoystickTrigger, JoystickPlayground } from './StyledJoystick'
 import { useTh } from '../../styles'
-import { Portal } from '../UI'
 import { useTransform } from '../../hooks'
 import type { Vector2d } from '../../types'
 import type { Vector2dProps } from './vector2d-types'
@@ -126,12 +125,10 @@ export function Joystick({ value, settings, onUpdate }: JoystickProps) {
   return (
     <JoystickTrigger ref={joystickeRef} {...bind()}>
       {joystickShown && (
-        <Portal>
-          <JoystickPlayground ref={playgroundRef} isOutOfBounds={isOutOfBounds}>
-            <div />
-            <span ref={spanRef} />
-          </JoystickPlayground>
-        </Portal>
+        <JoystickPlayground ref={playgroundRef} isOutOfBounds={isOutOfBounds}>
+          <div />
+          <span ref={spanRef} />
+        </JoystickPlayground>
       )}
     </JoystickTrigger>
   )


### PR DESCRIPTION
The joystick breaks on null ref while inside a Portal. 
To fix this: 

- Removed Portal to have ref in Joystick.tsx
- Reset z-index to auto in StyledUI.ts