### PR TITLE
Change `hidden` prop value to hide GUI from false to true in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ export default function MyApp() {
 
 ### Disabling the GUI
 
-Each instance of the `useControls` hook will render the panel. If you want to completely disable the GUI based on preferences, you need to explicitly set `hidden` to false.
+Each instance of the `useControls` hook will render the panel. If you want to completely disable the GUI based on preferences, you need to explicitly set `hidden` to true.
 
 ```jsx
 import { Leva } from 'leva'
@@ -40,7 +40,7 @@ function MyComponent() {
 export default function MyApp() {
   return (
     <>
-      <Leva {...config} hidden={false} />
+      <Leva {...config} hidden={true} />
     </>
   )
 }


### PR DESCRIPTION
The configuration docs say that explicitly setting the `hidden` prop to false will hide the GUI, but I believe this to be an oversight. Setting it to true actually hides Leva.